### PR TITLE
[Phase 1] Fix frontend Dockerfile: npm install instead of npm ci

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## What this does
Fixes frontend build failure. npm ci requires package-lock.json which doesn't exist yet.

## Issue
No issue — build fix.

## How to test
docker compose build frontend should succeed.