### PR TITLE
[Phase 2] Add Ollama client for chat and embeddings

### DIFF
--- a/backend/models/ollama_client.py
+++ b/backend/models/ollama_client.py
@@ -1,0 +1,37 @@
+import httpx
+import os
+
+OLLAMA_BASE_URL = f"http://{os.getenv('OLLAMA_HOST', 'ollama')}:{os.getenv('OLLAMA_PORT', 11434)}"
+
+async def chat(model, messages, temperature, top_p, max_tokens):
+    async with httpx.AsyncClient(timeout=60) as client:
+        response = await client.post(
+            f'{OLLAMA_BASE_URL}/api/chat',
+            json={
+                "model": model,
+                "messages": messages,
+                "options": {
+                    "temperature": temperature,
+                    "top_p": top_p,
+                    "num_predict": max_tokens
+                    },
+                "stream": False
+            }
+        )
+        response.raise_for_status()
+        return response.json()['message']['content']
+
+
+
+async def embed(model, text):
+    async with httpx.AsyncClient(timeout=60) as client:
+        response = await client.post(
+            f'{OLLAMA_BASE_URL}/api/embedding',
+            json={
+                "model": model,
+                "prompt": text
+            }
+        )
+        response.raise_for_status()
+        return response.json()['embedding']
+


### PR DESCRIPTION
## What this does
Unified async HTTP client for all Ollama calls. Handles chat completions and embeddings.

## Issue
Closes #13

## How to test
docker compose up → curl http://localhost:8000/api/models/test