### PR TITLE
[Phase 2] Add model router to select config by intent

### DIFF
--- a/backend/models/model_router.py
+++ b/backend/models/model_router.py
@@ -1,0 +1,7 @@
+from config import MODEL_CONFIG
+
+def get_model_config(intent: str) -> dict:
+    for config in MODEL_CONFIG.values():
+        if 'intents' in config and intent in config['intents']:
+            return config
+    return MODEL_CONFIG['primary']


### PR DESCRIPTION
## What this does
Given an intent string, returns the correct model config from MODEL_CONFIG. Falls back to primary on no match.

## Issue
Closes #14

## How to test
get_model_config('preparation') should return rag config. get_model_config('unknown') should return primary config.