### PR TITLE
[Phase 2] Fix model names to correct Ollama registry names

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,13 +1,13 @@
 MODEL_CONFIG = {
     "primary": {
-        "model": "typhoon2-8b-instruct",
+        "model": "llama3.2:1b",  # TODO: switch to scb10x/llama3.1-typhoon2-8b-instruct when pulled
         "intents": ["general", "eligibility", "recommendation", "career"],
         "temperature": 0.3,
         "top_p": 0.9,
         "max_tokens": 1000
     },
     "rag": {
-        "model": "typhoon2-8b-instruct",
+        "model": "llama3.2:1b",  # TODO: switch to scb10x/llama3.1-typhoon2-8b-instruct when pulled
         "intents": ["preparation", "comparison"],
         "temperature": 0.2,   # lower — needs to stay grounded to retrieved context
         "top_p": 0.85,


### PR DESCRIPTION
## What this does
Updates primary and rag model names. typhoon2-8b-instruct does not exist in Ollama registry. Using llama3.2:1b for now with TODO to switch to scb10x/llama3.1-typhoon2-8b-instruct when pulled.

## Issue
No issue — bug fix discovered during testing.

## How to test
curl 'http://localhost:8000/api/models/test?intent=general' should return a response.