### PR TITLE
[Phase 2] Fix intent names to match new architecture

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,14 +1,14 @@
 MODEL_CONFIG = {
     "primary": {
         "model": "scb10x/llama3.1-typhoon2-8b-instruct", 
-        "intents": ["general", "eligibility", "recommendation", "career"],
+        "intents": ['dreamer_chat', 'tcas_chat'],
         "temperature": 0.3,
         "top_p": 0.9,
         "max_tokens": 1000
     },
     "rag": {
         "model": "scb10x/llama3.1-typhoon2-8b-instruct",
-        "intents": ["preparation", "comparison"],
+        "intents": ['tcas_rag_retrieval'],
         "temperature": 0.2,   # lower — needs to stay grounded to retrieved context
         "top_p": 0.85,
         "max_tokens": 1500
@@ -17,7 +17,7 @@ MODEL_CONFIG = {
         "model": "nomic-embed-text"
     },
     "fallback": {
-        "model": "llama3.1-8b",
+        "model": "llama3.1:8b",
         "trigger": "primary_model_failure"
     }
 }


### PR DESCRIPTION
## What this does
Updates intent names in MODEL_CONFIG to align with new 2-agent architecture from CLAUDE.md.

- primary intents: dreamer_chat, tcas_chat
- rag intents: tcas_rag_retrieval
- fallback model: llama3.1:8b (correct Ollama format)

## Issue
Closes #12

## How to test
```python
from config import MODEL_CONFIG
assert MODEL_CONFIG['primary']['intents'] == ['dreamer_chat', 'tcas_chat']
assert MODEL_CONFIG['rag']['intents'] == ['tcas_rag_retrieval']
assert MODEL_CONFIG['fallback']['model'] == 'llama3.1:8b'
```