### PR TITLE
[Phase 11] Test eligibility engine with 12 student profiles

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ asyncpg==0.29.0
 redis[hiredis]==5.0.8
 python-dotenv==1.0.1
 firebase-admin==6.5.0
+pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,223 @@
+"""Test fixtures for the eligibility engine test suite.
+
+Session-scoped:
+  db_pool     — initialises and tears down the asyncpg connection pool once per
+                test run.  Requires a running Postgres instance (the same Docker
+                Compose one used in development).
+
+  seed_tcas   — inserts one university / faculty / major / round-3 project
+                row set that all integration tests share.  Cleaned up after the
+                session.
+
+Function-scoped:
+  make_user   — factory that inserts a user + user_profiles row and returns the
+                user_id UUID.  Deletes the user (cascade) after each test.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from decimal import Decimal
+from typing import AsyncGenerator
+
+import asyncpg
+import pytest
+
+from db.postgres import init_pool, close_pool, fetch, fetchrow, execute
+
+
+# ── DB pool ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session", autouse=True)
+async def db_pool():
+    await init_pool()
+    yield
+    await close_pool()
+
+
+# ── Shared TCAS seed ──────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+async def seed_tcas(db_pool):
+    """Insert a minimal Round-3 project hierarchy for 2026.
+
+    Returns a dict of IDs so individual tests can reference specific rows.
+    """
+    u_id = (await fetchrow(
+        """INSERT INTO universities (name, location) VALUES ($1, $2)
+           ON CONFLICT (name) DO UPDATE SET location = EXCLUDED.location
+           RETURNING id""",
+        "Test University", "Bangkok",
+    ))["id"]
+
+    # Engineering faculty
+    f_eng_id = (await fetchrow(
+        """INSERT INTO faculties (university_id, name) VALUES ($1, $2)
+           RETURNING id""",
+        u_id, "Engineering",
+    ))["id"]
+
+    # Medicine faculty
+    f_med_id = (await fetchrow(
+        """INSERT INTO faculties (university_id, name) VALUES ($1, $2)
+           RETURNING id""",
+        u_id, "Medicine",
+    ))["id"]
+
+    # Majors
+    m_cs_id = (await fetchrow(
+        "INSERT INTO majors (faculty_id, name, field) VALUES ($1,$2,$3) RETURNING id",
+        f_eng_id, "Computer Science", "Engineering",
+    ))["id"]
+
+    m_med_id = (await fetchrow(
+        "INSERT INTO majors (faculty_id, name, field) VALUES ($1,$2,$3) RETURNING id",
+        f_med_id, "Medicine", "Health Science",
+    ))["id"]
+
+    # Science major — no GPAX min, needs bio/chem but not math
+    f_sci_id = (await fetchrow(
+        "INSERT INTO faculties (university_id, name) VALUES ($1,$2) RETURNING id",
+        u_id, "Science",
+    ))["id"]
+    m_bio_id = (await fetchrow(
+        "INSERT INTO majors (faculty_id, name, field) VALUES ($1,$2,$3) RETURNING id",
+        f_sci_id, "Biology", "Science",
+    ))["id"]
+
+    # Pharmacy major — needs chem + bio, no math
+    f_pharm_id = (await fetchrow(
+        "INSERT INTO faculties (university_id, name) VALUES ($1,$2) RETURNING id",
+        u_id, "Pharmacy",
+    ))["id"]
+    m_pharm_id = (await fetchrow(
+        "INSERT INTO majors (faculty_id, name, field) VALUES ($1,$2,$3) RETURNING id",
+        f_pharm_id, "Pharmacy", "Health Science",
+    ))["id"]
+
+    # TCAS Rounds (year=2026, round 3)
+    async def mk_round(major_id):
+        return (await fetchrow(
+            "INSERT INTO tcas_rounds (major_id, round_number, year) VALUES ($1,3,2026) RETURNING id",
+            major_id,
+        ))["id"]
+
+    r_cs_id = await mk_round(m_cs_id)
+    r_med_id = await mk_round(m_med_id)
+    r_bio_id = await mk_round(m_bio_id)
+    r_pharm_id = await mk_round(m_pharm_id)
+
+    # Admission projects
+    async def mk_project(round_id, name, gpax_min, seats):
+        return (await fetchrow(
+            """INSERT INTO admission_projects
+                 (tcas_round_id, project_name, seats, gpax_min)
+               VALUES ($1,$2,$3,$4) RETURNING id""",
+            round_id, name,
+            seats,
+            Decimal(str(gpax_min)) if gpax_min is not None else None,
+        ))["id"]
+
+    ap_cs_id   = await mk_project(r_cs_id,   "CS Admission",       3.0, 30)
+    ap_med_id  = await mk_project(r_med_id,  "Medical Admission",  3.5, 20)
+    ap_bio_id  = await mk_project(r_bio_id,  "Biology Admission",  None, 25)
+    ap_pharm_id = await mk_project(r_pharm_id, "Pharmacy Admission", 3.0, 15)
+
+    # Subject requirements
+    async def mk_req(ap_id, subject, min_score, weight):
+        await execute(
+            """INSERT INTO subject_requirements
+                 (admission_project_id, subject, min_score, weight_percent)
+               VALUES ($1,$2,$3,$4)""",
+            ap_id, subject,
+            min_score, weight,
+        )
+
+    # CS: TGAT1 >= 50, A_LEVEL_MATH1 >= 40 (weighted, no floor)
+    await mk_req(ap_cs_id,    "TGAT1",          50.0, 30.0)
+    await mk_req(ap_cs_id,    "A_LEVEL_MATH1",  40.0, 70.0)
+
+    # Medicine: TGAT1 >= 60, TPAT2 >= 60, A_LEVEL_BIOLOGY >= 70, A_LEVEL_CHEMISTRY >= 70
+    await mk_req(ap_med_id,   "TGAT1",              60.0, 20.0)
+    await mk_req(ap_med_id,   "TPAT2",              60.0, 20.0)
+    await mk_req(ap_med_id,   "A_LEVEL_BIOLOGY",    70.0, 30.0)
+    await mk_req(ap_med_id,   "A_LEVEL_CHEMISTRY",  70.0, 30.0)
+
+    # Biology: A_LEVEL_BIOLOGY >= 50, A_LEVEL_CHEMISTRY >= 50 (no GPAX min)
+    await mk_req(ap_bio_id,   "A_LEVEL_BIOLOGY",    50.0, 50.0)
+    await mk_req(ap_bio_id,   "A_LEVEL_CHEMISTRY",  50.0, 50.0)
+
+    # Pharmacy: A_LEVEL_CHEMISTRY >= 60, A_LEVEL_BIOLOGY >= 50
+    await mk_req(ap_pharm_id, "A_LEVEL_CHEMISTRY",  60.0, 60.0)
+    await mk_req(ap_pharm_id, "A_LEVEL_BIOLOGY",    50.0, 40.0)
+
+    ids = dict(
+        university_id=u_id,
+        faculty_eng_id=f_eng_id,
+        faculty_med_id=f_med_id,
+        faculty_sci_id=f_sci_id,
+        faculty_pharm_id=f_pharm_id,
+        major_cs_id=m_cs_id,
+        major_med_id=m_med_id,
+        major_bio_id=m_bio_id,
+        major_pharm_id=m_pharm_id,
+        round_cs_id=r_cs_id,
+        round_med_id=r_med_id,
+        round_bio_id=r_bio_id,
+        round_pharm_id=r_pharm_id,
+        ap_cs_id=ap_cs_id,
+        ap_med_id=ap_med_id,
+        ap_bio_id=ap_bio_id,
+        ap_pharm_id=ap_pharm_id,
+    )
+
+    yield ids
+
+    # Teardown — cascade from university removes everything beneath it
+    await execute("DELETE FROM universities WHERE id = $1", u_id)
+
+
+# ── Per-test user factory ─────────────────────────────────────────────────────
+
+@pytest.fixture
+async def make_user(db_pool):
+    """Return an async factory: make_user(gpax, scores).
+
+    gpax:   float | None
+    scores: dict[subject_str, score_float]
+
+    Returns the user_id UUID. Cleans up (cascade) after each test.
+    """
+    created: list[uuid.UUID] = []
+
+    async def _factory(gpax=None, scores=None):
+        uid = uuid.uuid4()
+        fake_fuid = f"test_{uid.hex}"
+        fake_email = f"{uid.hex[:8]}@test.local"
+
+        await execute(
+            """INSERT INTO users (id, email, firebase_uid)
+               VALUES ($1, $2, $3)""",
+            uid, fake_email, fake_fuid,
+        )
+        await execute(
+            """INSERT INTO user_profiles (user_id, gpax)
+               VALUES ($1, $2)""",
+            uid,
+            Decimal(str(gpax)) if gpax is not None else None,
+        )
+        if scores:
+            for subject, score in scores.items():
+                await execute(
+                    """INSERT INTO user_test_scores (user_id, subject, score, exam_year)
+                       VALUES ($1, $2, $3, 2026)""",
+                    uid, subject, score,
+                )
+        created.append(uid)
+        return uid
+
+    yield _factory
+
+    for uid in created:
+        await execute("DELETE FROM users WHERE id = $1", uid)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,7 +29,7 @@ from db.postgres import init_pool, close_pool, fetch, fetchrow, execute
 
 # ── DB pool ───────────────────────────────────────────────────────────────────
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 async def db_pool():
     await init_pool()
     yield

--- a/backend/tests/test_eligibility.py
+++ b/backend/tests/test_eligibility.py
@@ -1,0 +1,226 @@
+"""Integration tests for check_eligibility() against a live PostgreSQL instance.
+
+Requires the Docker Compose stack to be running with at least postgres available.
+The seed_tcas fixture inserts a minimal 2026 project set with 4 projects:
+
+  CS Admission    — GPAX >= 3.0, TGAT1 >= 50, A_LEVEL_MATH1 >= 40
+  Medical         — GPAX >= 3.5, TGAT1 >= 60, TPAT2 >= 60, BIO >= 70, CHEM >= 70
+  Biology         — No GPAX min, A_LEVEL_BIOLOGY >= 50, A_LEVEL_CHEMISTRY >= 50
+  Pharmacy        — GPAX >= 3.0, A_LEVEL_CHEMISTRY >= 60, A_LEVEL_BIOLOGY >= 50
+
+Each test profile exercises a distinct eligibility scenario.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engines.eligibility_engine import check_eligibility
+
+
+def _project_ids(results):
+    return {r["project_name"] for r in results}
+
+
+def _eligible_names(results):
+    return {r["project_name"] for r in results if r["eligible"]}
+
+
+def _ineligible_names(results):
+    return {r["project_name"] for r in results if not r["eligible"]}
+
+
+# ── Profile 1: Excellent student ──────────────────────────────────────────────
+
+async def test_profile_excellent_eligible_for_all(seed_tcas, make_user):
+    """GPAX 3.95, top scores in everything → all 4 projects eligible."""
+    uid = await make_user(gpax=3.95, scores={
+        "TGAT1": 95.0, "TPAT2": 95.0,
+        "A_LEVEL_MATH1": 90.0,
+        "A_LEVEL_BIOLOGY": 90.0,
+        "A_LEVEL_CHEMISTRY": 90.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    assert len(results) == 4
+    assert _eligible_names(results) == {
+        "CS Admission", "Medical Admission", "Biology Admission", "Pharmacy Admission"
+    }
+
+
+# ── Profile 2: Good engineering student ───────────────────────────────────────
+
+async def test_profile_engineering_eligible_cs_only(seed_tcas, make_user):
+    """GPAX 3.5, strong math/TGAT but no bio/chem → CS only."""
+    uid = await make_user(gpax=3.5, scores={
+        "TGAT1": 80.0,
+        "A_LEVEL_MATH1": 75.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    assert "CS Admission" in _eligible_names(results)
+    assert "Medical Admission" not in _eligible_names(results)
+    assert "Biology Admission" not in _eligible_names(results)
+
+
+# ── Profile 3: Average GPAX ───────────────────────────────────────────────────
+
+async def test_profile_average_gpax_3_0_passes_cs_threshold(seed_tcas, make_user):
+    """GPAX exactly 3.0 clears CS and Pharmacy thresholds; too low for Medicine."""
+    uid = await make_user(gpax=3.0, scores={
+        "TGAT1": 55.0, "A_LEVEL_MATH1": 45.0,
+        "A_LEVEL_BIOLOGY": 55.0, "A_LEVEL_CHEMISTRY": 65.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    assert "CS Admission" in _eligible_names(results)
+    assert "Pharmacy Admission" in _eligible_names(results)
+    assert "Medical Admission" not in _eligible_names(results)
+
+
+# ── Profile 4: Low GPAX with high scores ─────────────────────────────────────
+
+async def test_profile_low_gpax_fails_projects_with_gpax_min(seed_tcas, make_user):
+    """GPAX 2.5 — fails CS (3.0) and Medicine (3.5) and Pharmacy (3.0) thresholds.
+    Biology has no GPAX min, so passes if scores are there."""
+    uid = await make_user(gpax=2.5, scores={
+        "TGAT1": 90.0, "TPAT2": 90.0,
+        "A_LEVEL_MATH1": 90.0,
+        "A_LEVEL_BIOLOGY": 90.0,
+        "A_LEVEL_CHEMISTRY": 90.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    eligible = _eligible_names(results)
+    assert "Biology Admission" in eligible
+    assert "CS Admission" not in eligible
+    assert "Medical Admission" not in eligible
+    assert "Pharmacy Admission" not in eligible
+
+
+# ── Profile 5: All scores and GPAX exactly at minimum ────────────────────────
+
+async def test_profile_borderline_all_at_minimum_eligible(seed_tcas, make_user):
+    """All values exactly at their minimums → should be eligible for CS and Biology."""
+    uid = await make_user(gpax=3.0, scores={
+        "TGAT1": 50.0,
+        "A_LEVEL_MATH1": 40.0,
+        "A_LEVEL_BIOLOGY": 50.0,
+        "A_LEVEL_CHEMISTRY": 50.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    assert "CS Admission" in _eligible_names(results)
+    assert "Biology Admission" in _eligible_names(results)
+
+
+# ── Profile 6: One score just below minimum ───────────────────────────────────
+
+async def test_profile_one_subject_just_below_min_ineligible(seed_tcas, make_user):
+    """CS requires A_LEVEL_MATH1 >= 40.  Score is 39.9 → CS ineligible."""
+    uid = await make_user(gpax=3.5, scores={
+        "TGAT1": 60.0,
+        "A_LEVEL_MATH1": 39.9,
+    })
+    results = await check_eligibility(uid, year=2026)
+    assert "CS Admission" not in _eligible_names(results)
+
+
+# ── Profile 7: No test scores at all ─────────────────────────────────────────
+
+async def test_profile_no_test_scores_fails_subject_requirements(seed_tcas, make_user):
+    """GPAX 3.8 but no scores → every project with subject requirements is
+    ineligible.  Biology has subject mins so also fails."""
+    uid = await make_user(gpax=3.8, scores={})
+    results = await check_eligibility(uid, year=2026)
+    assert len(_eligible_names(results)) == 0
+
+
+# ── Profile 8: Science student — good bio/chem, no math ──────────────────────
+
+async def test_profile_science_student_eligible_bio_and_pharmacy(seed_tcas, make_user):
+    """Bio/chem but no TGAT1 or math → only Biology and Pharmacy eligible."""
+    uid = await make_user(gpax=3.2, scores={
+        "A_LEVEL_BIOLOGY": 80.0,
+        "A_LEVEL_CHEMISTRY": 75.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    eligible = _eligible_names(results)
+    assert "Biology Admission" in eligible
+    assert "Pharmacy Admission" in eligible
+    assert "CS Admission" not in eligible
+    assert "Medical Admission" not in eligible
+
+
+# ── Profile 9: No GPAX (never filled profile) ────────────────────────────────
+
+async def test_profile_no_gpax_fails_all_projects_with_gpax_min(seed_tcas, make_user):
+    """User has great scores but no GPAX on file.  Anything with a GPAX min is
+    automatically ineligible; Biology (no min) depends on scores."""
+    uid = await make_user(gpax=None, scores={
+        "TGAT1": 90.0, "TPAT2": 90.0,
+        "A_LEVEL_MATH1": 85.0,
+        "A_LEVEL_BIOLOGY": 90.0,
+        "A_LEVEL_CHEMISTRY": 90.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    eligible = _eligible_names(results)
+    assert "Biology Admission" in eligible
+    assert "CS Admission" not in eligible
+    assert "Pharmacy Admission" not in eligible
+
+
+# ── Profile 10: Medical track ─────────────────────────────────────────────────
+
+async def test_profile_medical_track_eligible_for_medicine(seed_tcas, make_user):
+    """High GPAX + all four medicine requirements met → Medicine eligible."""
+    uid = await make_user(gpax=3.8, scores={
+        "TGAT1": 75.0,
+        "TPAT2": 70.0,
+        "A_LEVEL_BIOLOGY": 80.0,
+        "A_LEVEL_CHEMISTRY": 80.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    assert "Medical Admission" in _eligible_names(results)
+
+
+# ── Profile 11: Pharmacy specialist — chem+bio, no math ──────────────────────
+
+async def test_profile_pharmacy_only_eligible(seed_tcas, make_user):
+    """Specifically fits Pharmacy (chem 65 + bio 55) but TGAT1 missing → CS fails."""
+    uid = await make_user(gpax=3.1, scores={
+        "A_LEVEL_CHEMISTRY": 65.0,
+        "A_LEVEL_BIOLOGY": 55.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    eligible = _eligible_names(results)
+    assert "Pharmacy Admission" in eligible
+    assert "CS Admission" not in eligible
+    assert "Medical Admission" not in eligible
+
+
+# ── Profile 12: All scores and GPAX one step below every minimum ──────────────
+
+async def test_profile_all_one_below_minimum_ineligible(seed_tcas, make_user):
+    """GPAX 2.99, all scores 1 point below floor → zero eligible projects."""
+    uid = await make_user(gpax=2.99, scores={
+        "TGAT1": 49.0,
+        "TPAT2": 59.0,
+        "A_LEVEL_MATH1": 39.0,
+        "A_LEVEL_BIOLOGY": 49.0,
+        "A_LEVEL_CHEMISTRY": 59.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    assert len(_eligible_names(results)) == 0
+
+
+# ── Ordering ──────────────────────────────────────────────────────────────────
+
+async def test_eligible_projects_sorted_first(seed_tcas, make_user):
+    """Results list must have eligible=True rows before eligible=False rows."""
+    uid = await make_user(gpax=3.5, scores={
+        "TGAT1": 80.0,
+        "A_LEVEL_MATH1": 70.0,
+    })
+    results = await check_eligibility(uid, year=2026)
+    saw_ineligible = False
+    for r in results:
+        if not r["eligible"]:
+            saw_ineligible = True
+        if saw_ineligible:
+            assert not r["eligible"], "Eligible project appeared after ineligible one"

--- a/backend/tests/test_evaluate.py
+++ b/backend/tests/test_evaluate.py
@@ -1,0 +1,175 @@
+"""Unit tests for engines.eligibility_engine._evaluate.
+
+_evaluate() is a pure function — no I/O, no DB.  Every case here uses
+constructed project/requirement dicts so tests run without a database.
+
+Project dict shape mirrors what _fetch_projects_with_requirements returns:
+  ap_id, project_name, seats, gpax_min, source_url, accepts_ged,
+  round_number, year, major_id, major_name, faculty_name, university_name,
+  requirements: [{subject, min_score, weight_percent}, ...]
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from engines.eligibility_engine import _evaluate
+
+
+def _proj(gpax_min=None, requirements=None, *, name="Test Project"):
+    return {
+        "ap_id": str(uuid.uuid4()),
+        "project_name": name,
+        "seats": 30,
+        "gpax_min": gpax_min,
+        "source_url": None,
+        "accepts_ged": False,
+        "round_number": 3,
+        "year": 2026,
+        "major_id": str(uuid.uuid4()),
+        "major_name": "Test Major",
+        "faculty_name": "Test Faculty",
+        "university_name": "Test University",
+        "requirements": requirements or [],
+    }
+
+
+def _req(subject, min_score=None, weight=100.0):
+    return {"subject": subject, "min_score": min_score, "weight_percent": weight}
+
+
+# ── GPAX checks ───────────────────────────────────────────────────────────────
+
+def test_no_gpax_min_always_passes_gpax():
+    result = _evaluate(_proj(gpax_min=None), student_gpax=None, student_scores={})
+    assert result["gpax_ok"] is True
+
+
+def test_gpax_above_min_passes():
+    result = _evaluate(_proj(gpax_min=3.0), student_gpax=3.5, student_scores={})
+    assert result["gpax_ok"] is True
+
+
+def test_gpax_exactly_at_min_passes():
+    result = _evaluate(_proj(gpax_min=3.0), student_gpax=3.0, student_scores={})
+    assert result["gpax_ok"] is True
+
+
+def test_gpax_below_min_fails():
+    result = _evaluate(_proj(gpax_min=3.0), student_gpax=2.99, student_scores={})
+    assert result["gpax_ok"] is False
+    assert result["eligible"] is False
+
+
+def test_gpax_none_with_min_required_fails():
+    result = _evaluate(_proj(gpax_min=3.0), student_gpax=None, student_scores={})
+    assert result["gpax_ok"] is False
+    assert result["eligible"] is False
+
+
+# ── Subject score checks ──────────────────────────────────────────────────────
+
+def test_subject_above_min_passes():
+    proj = _proj(requirements=[_req("TGAT1", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=4.0, student_scores={"TGAT1": 75.0})
+    assert result["subject_results"][0]["ok"] is True
+    assert result["eligible"] is True
+
+
+def test_subject_exactly_at_min_passes():
+    proj = _proj(requirements=[_req("TGAT1", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=4.0, student_scores={"TGAT1": 50.0})
+    assert result["subject_results"][0]["ok"] is True
+    assert result["eligible"] is True
+
+
+def test_subject_below_min_fails():
+    proj = _proj(requirements=[_req("TGAT1", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=4.0, student_scores={"TGAT1": 49.9})
+    assert result["subject_results"][0]["ok"] is False
+    assert result["eligible"] is False
+
+
+def test_subject_missing_score_with_min_fails():
+    proj = _proj(requirements=[_req("TGAT1", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=4.0, student_scores={})
+    sr = result["subject_results"][0]
+    assert sr["student_score"] is None
+    assert sr["ok"] is False
+    assert result["eligible"] is False
+
+
+def test_subject_no_min_always_passes():
+    proj = _proj(requirements=[_req("A_LEVEL_MATH1", min_score=None)])
+    result = _evaluate(proj, student_gpax=4.0, student_scores={})
+    assert result["subject_results"][0]["ok"] is True
+    assert result["eligible"] is True
+
+
+def test_one_failing_subject_makes_ineligible():
+    proj = _proj(requirements=[
+        _req("TGAT1", min_score=50.0),
+        _req("A_LEVEL_MATH1", min_score=40.0),
+    ])
+    result = _evaluate(proj, student_gpax=4.0, student_scores={"TGAT1": 80.0, "A_LEVEL_MATH1": 30.0})
+    assert result["eligible"] is False
+    assert result["subject_results"][1]["ok"] is False
+
+
+# ── Combined eligibility ───────────────────────────────────────────────────────
+
+def test_no_requirements_no_gpax_min_eligible():
+    result = _evaluate(_proj(), student_gpax=None, student_scores={})
+    assert result["eligible"] is True
+
+
+def test_gpax_fails_even_if_subjects_pass():
+    proj = _proj(gpax_min=3.5, requirements=[_req("TGAT1", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=3.0, student_scores={"TGAT1": 90.0})
+    assert result["gpax_ok"] is False
+    assert result["eligible"] is False
+
+
+def test_subjects_fail_even_if_gpax_passes():
+    proj = _proj(gpax_min=3.0, requirements=[_req("TGAT1", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=3.8, student_scores={"TGAT1": 40.0})
+    assert result["gpax_ok"] is True
+    assert result["eligible"] is False
+
+
+def test_all_pass_eligible():
+    proj = _proj(gpax_min=3.0, requirements=[
+        _req("TGAT1", min_score=50.0),
+        _req("A_LEVEL_MATH1", min_score=40.0),
+    ])
+    result = _evaluate(proj, student_gpax=3.5, student_scores={"TGAT1": 55.0, "A_LEVEL_MATH1": 45.0})
+    assert result["eligible"] is True
+    assert all(s["ok"] for s in result["subject_results"])
+
+
+# ── Result shape ──────────────────────────────────────────────────────────────
+
+def test_result_contains_expected_fields():
+    proj = _proj(gpax_min=3.0, requirements=[_req("TGAT1", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=3.5, student_scores={"TGAT1": 60.0})
+
+    expected_keys = {
+        "admission_project_id", "project_name", "major", "faculty", "university",
+        "round_number", "year", "seats", "gpax_min", "gpax_ok",
+        "subject_results", "eligible", "source_url",
+    }
+    assert expected_keys == result.keys()
+
+
+def test_subject_result_contains_weight():
+    proj = _proj(requirements=[_req("TGAT1", min_score=50.0, weight=30.0)])
+    result = _evaluate(proj, student_gpax=None, student_scores={"TGAT1": 60.0})
+    assert result["subject_results"][0]["weight_percent"] == 30.0
+
+
+def test_student_score_reflected_in_result():
+    proj = _proj(requirements=[_req("A_LEVEL_BIOLOGY", min_score=50.0)])
+    result = _evaluate(proj, student_gpax=None, student_scores={"A_LEVEL_BIOLOGY": 75.0})
+    assert result["subject_results"][0]["student_score"] == 75.0


### PR DESCRIPTION
## What this does

Adds the full test suite for `engines/eligibility_engine.py` covering Phase 11 acceptance criteria for issue #51.

**Pure unit tests (`tests/test_evaluate.py` — 18 cases)**
- GPAX threshold logic: above/at/below min, null GPAX with required min
- Subject score logic: above/at/below min, missing score, no-minimum subject, one failing kills eligibility
- Combined: GPAX pass + subject fail, GPAX fail + subject pass, all-pass
- Result shape: expected keys, weight_percent, student_score reflected

**Integration tests (`tests/test_eligibility.py` — 13 cases)**
Seed: 4 Round-3 projects for 2026 — CS, Medicine, Biology, Pharmacy

12 student profiles:
1. Excellent (all high) — all 4 eligible
2. Engineering (math/TGAT, no bio/chem) — CS only
3. GPAX 3.0 — CS + Pharmacy, not Medicine
4. GPAX 2.5 (high scores) — Biology only (no GPAX min)
5. All values at exact minimum — eligible (boundary)
6. One score 0.1 below min — ineligible for that project
7. No test scores — zero eligible
8. Science (bio/chem only) — Biology + Pharmacy
9. No GPAX on file — Biology only
10. Medical track — Medicine eligible
11. Pharmacy specialist — Pharmacy only
12. All values 1 below every minimum — zero eligible
+ Ordering: eligible rows sort before ineligible

**Infrastructure:**
- pytest 8.3.4 + pytest-asyncio 0.24.0 added to requirements.txt
- pytest.ini with asyncio_mode = auto
- conftest.py: session-scoped db_pool + seed_tcas, function-scoped make_user factory
- db_pool is NOT autouse — unit tests run without any DB

## Issue
Closes #51

## How to test
```
cd backend && python -m pytest tests/test_evaluate.py -v
docker compose up -d postgres && python -m pytest tests/test_eligibility.py -v
```