### PR TITLE
[Phase 8] Online Runtime — Mode Selector, Orchestrator, Chat Endpoints

### DIFF
--- a/backend/engines/mode_selector.py
+++ b/backend/engines/mode_selector.py
@@ -1,0 +1,26 @@
+"""Mode selector — explicit UI-driven routing between Flow A and Flow B.
+
+Why not LLM-based intent detection?
+  CLAUDE.md §6.1: "Instead of relying on LLM intent classification (which is
+  prone to errors), the system uses explicit mode selection from the frontend UI."
+  The frontend sends ai_mode as part of session creation; this module validates
+  and normalises that value so the rest of the system can trust it.
+"""
+
+from __future__ import annotations
+
+VALID_MODES = {"dreamer", "tcas_rag"}
+
+
+def validate_mode(ai_mode: str) -> str:
+    """Validate and normalise the ai_mode string sent by the frontend.
+
+    Returns the normalised mode string ("dreamer" or "tcas_rag").
+    Raises ValueError for any unrecognised value so the API can return 422.
+    """
+    mode = ai_mode.lower().strip()
+    if mode not in VALID_MODES:
+        raise ValueError(
+            f"Invalid ai_mode '{ai_mode}'. Must be one of: {sorted(VALID_MODES)}"
+        )
+    return mode

--- a/backend/engines/orchestrator.py
+++ b/backend/engines/orchestrator.py
@@ -48,3 +48,21 @@ async def handle_dreamer_message(
     cfg = get_model_config("dreamer_chat")
     messages = [{"role": "system", "content": system_prompt}] + history + [{"role": "user", "content": content}]
     return await chat(cfg["model"], messages, cfg["temperature"], cfg["top_p"], cfg["max_tokens"])
+
+
+async def handle_tcas_message(
+    user_id: UUID,
+    session_id: UUID,
+    content: str,
+    history: list[dict],
+) -> str:
+    """Generate a Flow B (TCAS advisor) response grounded in SQL eligibility data.
+
+    Phase 6 RAG hook: insert retrieval between check_eligibility and compose_tcas_prompt.
+    """
+    profile = await _load_user_profile(user_id)
+    eligibility = await check_eligibility(user_id=user_id)
+    system_prompt = compose_tcas_prompt(profile, eligibility)
+    cfg = get_model_config("tcas_chat")
+    messages = [{"role": "system", "content": system_prompt}] + history + [{"role": "user", "content": content}]
+    return await chat(cfg["model"], messages, cfg["temperature"], cfg["top_p"], cfg["max_tokens"])

--- a/backend/engines/orchestrator.py
+++ b/backend/engines/orchestrator.py
@@ -1,0 +1,36 @@
+"""Request orchestrator — routes a user message through the correct AI flow.
+
+Flow A (dreamer):  profile → compose_dreamer_prompt → Typhoon2 → response
+Flow B (tcas_rag): profile → check_eligibility → compose_tcas_prompt → Typhoon2 → response
+
+After generation the orchestrator:
+  1. Saves both the user message and the AI response to chat_messages (Postgres).
+  2. Appends both to the Redis chat window for the next turn's context.
+
+RAG retrieval (Phase 6) will be inserted into handle_tcas_message between the
+eligibility check and the Ollama call — the slot is intentionally left open.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from db.postgres import fetchrow
+from engines.eligibility_engine import check_eligibility
+from engines.prompt_composer import compose_dreamer_prompt, compose_tcas_prompt
+from memory.long_term_memory import save_message
+from memory.session_memory import append_to_chat_window, get_chat_window, get_user_session
+from models.model_router import get_model_config
+from models.ollama_client import chat
+
+
+async def _load_user_profile(user_id: UUID) -> dict:
+    """Return the user's profile dict, preferring the Redis cache over a DB hit."""
+    cached = await get_user_session(str(user_id))
+    if cached:
+        return cached
+    row = await fetchrow(
+        "SELECT gpax, current_school FROM user_profiles WHERE user_id = $1",
+        user_id,
+    )
+    return dict(row) if row else {}

--- a/backend/engines/orchestrator.py
+++ b/backend/engines/orchestrator.py
@@ -34,3 +34,17 @@ async def _load_user_profile(user_id: UUID) -> dict:
         user_id,
     )
     return dict(row) if row else {}
+
+
+async def handle_dreamer_message(
+    user_id: UUID,
+    session_id: UUID,
+    content: str,
+    history: list[dict],
+) -> str:
+    """Generate a Flow A (Career Dreamer) response via Typhoon2."""
+    profile = await _load_user_profile(user_id)
+    system_prompt = compose_dreamer_prompt(profile)
+    cfg = get_model_config("dreamer_chat")
+    messages = [{"role": "system", "content": system_prompt}] + history + [{"role": "user", "content": content}]
+    return await chat(cfg["model"], messages, cfg["temperature"], cfg["top_p"], cfg["max_tokens"])

--- a/backend/engines/orchestrator.py
+++ b/backend/engines/orchestrator.py
@@ -66,3 +66,33 @@ async def handle_tcas_message(
     cfg = get_model_config("tcas_chat")
     messages = [{"role": "system", "content": system_prompt}] + history + [{"role": "user", "content": content}]
     return await chat(cfg["model"], messages, cfg["temperature"], cfg["top_p"], cfg["max_tokens"])
+
+
+async def handle_message(
+    session_id: UUID,
+    user_id: UUID,
+    ai_mode: str,
+    content: str,
+) -> str:
+    """Top-level dispatcher: load context → generate response → persist → return.
+
+    Order matters:
+      1. Load Redis window (fast, recent context for the model).
+      2. Generate response (the only slow step — Ollama call).
+      3. Persist to DB (durable history).
+      4. Update Redis window (so next turn has fresh context).
+    """
+    history = await get_chat_window(str(user_id), str(session_id))
+
+    if ai_mode == "dreamer":
+        response = await handle_dreamer_message(user_id, session_id, content, history)
+    else:
+        response = await handle_tcas_message(user_id, session_id, content, history)
+
+    await save_message(session_id, "user", content)
+    await save_message(session_id, "assistant", response)
+
+    await append_to_chat_window(str(user_id), str(session_id), "user", content)
+    await append_to_chat_window(str(user_id), str(session_id), "assistant", response)
+
+    return response

--- a/backend/engines/prompt_composer.py
+++ b/backend/engines/prompt_composer.py
@@ -1,0 +1,25 @@
+"""Prompt composer — build layered system prompts for each AI mode.
+
+Prompt structure (CLAUDE.md §6.7):
+  _MASTER_SYSTEM       ← static, frozen refusal rules
+  + user profile       ← GPAX, school (from PostgreSQL / Redis)
+  + mode template      ← Flow A (career) or Flow B (TCAS eligibility)
+  + retrieved context  ← eligibility SQL results for Flow B; RAG chunks later (Phase 6)
+"""
+
+from __future__ import annotations
+
+_MASTER_SYSTEM = """\
+You are AcadeMong, an AI advisor for Thai university students navigating the TCAS \
+university admissions system.
+
+Rules you must follow at all times:
+- Never state a GPAX minimum or exam score threshold unless it appears verbatim \
+in the data provided to you in this prompt.
+- If asked something outside TCAS admissions, university selection, or career \
+planning, politely decline and redirect the student.
+- Content inside <sql_result> tags comes directly from the database and is \
+ground truth — treat it as authoritative.
+- Respond in the same language the student uses (Thai or English). \
+Default to Thai if unclear.\
+"""

--- a/backend/engines/prompt_composer.py
+++ b/backend/engines/prompt_composer.py
@@ -48,3 +48,54 @@ def compose_dreamer_prompt(user_profile: dict) -> str:
         "interests once you have enough context. Be encouraging and realistic."
     )
     return "\n".join(lines)
+
+
+def compose_tcas_prompt(user_profile: dict, eligibility_results: list[dict]) -> str:
+    """System prompt for Flow B — TCAS advisor.
+
+    Injects SQL eligibility results as ground-truth context so the model never
+    has to invent thresholds. Results are capped (10 eligible / 5 ineligible)
+    to stay within a reasonable context budget.
+    """
+    lines = [_MASTER_SYSTEM, "\n## Student Profile"]
+    gpax = user_profile.get("gpax")
+    if gpax is not None:
+        lines.append(f"- GPAX: {gpax}")
+    else:
+        lines.append("- GPAX: not on file")
+
+    eligible = [r for r in eligibility_results if r["eligible"]]
+    ineligible = [r for r in eligibility_results if not r["eligible"]]
+
+    lines.append("\n<sql_result>")
+    lines.append(f"Total projects evaluated: {len(eligibility_results)}")
+    lines.append(f"Eligible: {len(eligible)}  |  Ineligible: {len(ineligible)}")
+
+    if eligible:
+        lines.append("\nELIGIBLE PROJECTS (student meets all requirements):")
+        for r in eligible[:10]:
+            gpax_label = f"GPAX≥{r['gpax_min']}" if r["gpax_min"] else "no GPAX min"
+            lines.append(
+                f"  ✓ {r['project_name']} — {r['university']} / {r['faculty']} / {r['major']} ({gpax_label})"
+            )
+        if len(eligible) > 10:
+            lines.append(f"  ... and {len(eligible) - 10} more eligible projects")
+
+    if ineligible:
+        lines.append("\nINELIGIBLE PROJECTS (requirements not met):")
+        for r in ineligible[:5]:
+            lines.append(
+                f"  ✗ {r['project_name']} — {r['university']} / {r['faculty']} / {r['major']}"
+            )
+        if len(ineligible) > 5:
+            lines.append(f"  ... and {len(ineligible) - 5} more ineligible projects")
+
+    lines.append("</sql_result>")
+    lines.append(
+        "\n## Your role\n"
+        "Answer the student's questions about their eligibility using ONLY the data "
+        "inside <sql_result> above. Never invent or guess a threshold. "
+        "If the student asks about a project not listed, tell them it is not in the "
+        "current dataset and suggest they check mytcas.com for the latest information."
+    )
+    return "\n".join(lines)

--- a/backend/engines/prompt_composer.py
+++ b/backend/engines/prompt_composer.py
@@ -23,3 +23,28 @@ ground truth — treat it as authoritative.
 - Respond in the same language the student uses (Thai or English). \
 Default to Thai if unclear.\
 """
+
+
+def compose_dreamer_prompt(user_profile: dict) -> str:
+    """System prompt for Flow A — Career Dreamer.
+
+    Builds: MASTER + student profile snippet + career-coaching instruction.
+    No eligibility data here; this mode is about exploring interests and strengths.
+    """
+    lines = [_MASTER_SYSTEM, "\n## Student Profile"]
+    gpax = user_profile.get("gpax")
+    school = user_profile.get("current_school")
+    if gpax is not None:
+        lines.append(f"- GPAX: {gpax}")
+    if school:
+        lines.append(f"- Current school: {school}")
+    if not gpax and not school:
+        lines.append("- (No profile data on file yet)")
+
+    lines.append(
+        "\n## Your role\n"
+        "Help this student explore their interests, strengths, and career aspirations. "
+        "Ask thoughtful, open-ended questions. Suggest fields of study that match their "
+        "interests once you have enough context. Be encouraging and realistic."
+    )
+    return "\n".join(lines)

--- a/backend/memory/long_term_memory.py
+++ b/backend/memory/long_term_memory.py
@@ -29,3 +29,16 @@ async def save_message(session_id: UUID, role: str, content: str) -> UUID:
         session_id, role, content,
     )
     return row["id"]
+
+
+async def get_session(session_id: UUID) -> dict | None:
+    """Fetch a chat_sessions row by id, or None if not found.
+
+    Includes user_id so callers can verify ownership before exposing
+    session data to the requesting user.
+    """
+    row = await fetchrow(
+        "SELECT id, user_id, ai_mode, created_at FROM chat_sessions WHERE id = $1",
+        session_id,
+    )
+    return dict(row) if row else None

--- a/backend/memory/long_term_memory.py
+++ b/backend/memory/long_term_memory.py
@@ -42,3 +42,15 @@ async def get_session(session_id: UUID) -> dict | None:
         session_id,
     )
     return dict(row) if row else None
+
+
+async def get_messages(session_id: UUID) -> list[dict]:
+    """Return all chat_messages for a session, ordered oldest-first."""
+    rows = await fetch(
+        """SELECT id, role, content, created_at
+           FROM chat_messages
+           WHERE session_id = $1
+           ORDER BY created_at""",
+        session_id,
+    )
+    return [dict(r) for r in rows]

--- a/backend/memory/long_term_memory.py
+++ b/backend/memory/long_term_memory.py
@@ -20,3 +20,12 @@ async def create_chat_session(user_id: UUID, ai_mode: str) -> UUID:
         user_id, ai_mode,
     )
     return row["id"]
+
+
+async def save_message(session_id: UUID, role: str, content: str) -> UUID:
+    """Persist one chat_messages row and return its id."""
+    row = await fetchrow(
+        "INSERT INTO chat_messages (session_id, role, content) VALUES ($1, $2, $3) RETURNING id",
+        session_id, role, content,
+    )
+    return row["id"]

--- a/backend/memory/long_term_memory.py
+++ b/backend/memory/long_term_memory.py
@@ -1,0 +1,22 @@
+"""Long-term memory — PostgreSQL helpers for chat sessions and messages.
+
+Why a separate module from session_memory?
+  session_memory.py owns Redis (fast, ephemeral, per-session window).
+  long_term_memory.py owns Postgres (durable, queryable, full history).
+  Keeping them separate means each can be swapped or tested independently.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from db.postgres import execute, fetch, fetchrow
+
+
+async def create_chat_session(user_id: UUID, ai_mode: str) -> UUID:
+    """Insert a new chat_sessions row and return its id."""
+    row = await fetchrow(
+        "INSERT INTO chat_sessions (user_id, ai_mode) VALUES ($1, $2) RETURNING id",
+        user_id, ai_mode,
+    )
+    return row["id"]

--- a/backend/memory/session_memory.py
+++ b/backend/memory/session_memory.py
@@ -82,3 +82,12 @@ async def set_chat_window(user_id: str, session_id: str, messages: list[dict], t
         json.dumps(messages, default=_session_serializer),
         ex=ttl,
     )
+
+
+async def append_to_chat_window(user_id: str, session_id: str, role: str, content: str, ttl: int = 7200):
+    """Append one message to the window, trimming to _WINDOW_SIZE most recent."""
+    messages = await get_chat_window(user_id, session_id)
+    messages.append({"role": role, "content": content})
+    if len(messages) > _WINDOW_SIZE:
+        messages = messages[-_WINDOW_SIZE:]
+    await set_chat_window(user_id, session_id, messages, ttl=ttl)

--- a/backend/memory/session_memory.py
+++ b/backend/memory/session_memory.py
@@ -71,3 +71,14 @@ async def get_chat_window(user_id: str, session_id: str) -> list[dict]:
         raise ConnectionError("Redis pool is not initialized.")
     raw = await redis_pool.get(f"session:{user_id}:{session_id}:window")
     return json.loads(raw) if raw else []
+
+
+async def set_chat_window(user_id: str, session_id: str, messages: list[dict], ttl: int = 7200):
+    """Overwrite the message window in Redis. TTL defaults to 2 hours."""
+    if not redis_pool:
+        raise ConnectionError("Redis pool is not initialized.")
+    await redis_pool.set(
+        f"session:{user_id}:{session_id}:window",
+        json.dumps(messages, default=_session_serializer),
+        ex=ttl,
+    )

--- a/backend/memory/session_memory.py
+++ b/backend/memory/session_memory.py
@@ -60,3 +60,14 @@ async def get_user_session(user_id: str) -> dict | None:
     session_key = f"session:{user_id}:profile"
     raw = await redis_pool.get(session_key)
     return json.loads(raw) if raw else None
+
+
+_WINDOW_SIZE = 10  # max messages kept hot in Redis per session
+
+
+async def get_chat_window(user_id: str, session_id: str) -> list[dict]:
+    """Return the in-session message window from Redis (empty list if not found)."""
+    if not redis_pool:
+        raise ConnectionError("Redis pool is not initialized.")
+    raw = await redis_pool.get(f"session:{user_id}:{session_id}:window")
+    return json.loads(raw) if raw else []

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -90,7 +90,27 @@ class EligibilityResponse(BaseModel):
     results: list[EligibilityResult]
 
 
-# ── Endpoints ─────────────────────────────────────────────────────────────────
+# ── Chat endpoints ────────────────────────────────────────────────────────────
+
+@router.post(
+    "/session",
+    response_model=CreateSessionResponse,
+    summary="Create a new chat session",
+    description="ai_mode must be 'dreamer' (Flow A) or 'tcas_rag' (Flow B).",
+)
+async def create_session(
+    body: CreateSessionRequest,
+    user: dict = Depends(get_current_user),
+):
+    try:
+        mode = validate_mode(body.ai_mode)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    session_id = await create_chat_session(user["id"], mode)
+    return CreateSessionResponse(session_id=str(session_id), ai_mode=mode)
+
+
+# ── Eligibility endpoints ──────────────────────────────────────────────────────
 
 @router.post(
     "/eligibility",

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -110,6 +110,28 @@ async def create_session(
     return CreateSessionResponse(session_id=str(session_id), ai_mode=mode)
 
 
+@router.post(
+    "/{session_id}/message",
+    response_model=MessageResponse,
+    summary="Send a message and receive an AI response",
+)
+async def send_message(
+    session_id: UUID,
+    body: SendMessageRequest,
+    user: dict = Depends(get_current_user),
+):
+    session = await get_session(session_id)
+    if not session or session["user_id"] != user["id"]:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+    response_text = await handle_message(
+        session_id=session_id,
+        user_id=user["id"],
+        ai_mode=session["ai_mode"],
+        content=body.content,
+    )
+    return MessageResponse(role="assistant", content=response_text)
+
+
 # ── Eligibility endpoints ──────────────────────────────────────────────────────
 
 @router.post(

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -132,6 +132,22 @@ async def send_message(
     return MessageResponse(role="assistant", content=response_text)
 
 
+@router.get(
+    "/{session_id}/messages",
+    response_model=HistoryResponse,
+    summary="Fetch full message history for a session",
+)
+async def get_message_history(
+    session_id: UUID,
+    user: dict = Depends(get_current_user),
+):
+    session = await get_session(session_id)
+    if not session or session["user_id"] != user["id"]:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+    messages = await get_messages(session_id)
+    return HistoryResponse(session_id=str(session_id), messages=messages)
+
+
 # ── Eligibility endpoints ──────────────────────────────────────────────────────
 
 @router.post(

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,13 +1,12 @@
-"""Chat router — eligibility query endpoint (current scope).
-
-This is the current-scope version of the chat router. It covers Flow B (TCAS
-eligibility) without RAG context — just deterministic SQL matching. Flow A
-(Career Dreamer) and RAG-augmented responses are deferred pending Phase 6/7.
+"""Chat router — conversational AI endpoints + eligibility utilities.
 
 Endpoints:
-    POST /api/chat/eligibility          — run eligibility check for current user
-    POST /api/chat/eligibility/{major_id} — scoped to a single major
-    GET  /api/chat/sessions             — list chat sessions for current user
+    POST /api/chat/session              — create a new chat session (dreamer or tcas_rag)
+    POST /api/chat/{session_id}/message — send a message, receive an AI response
+    GET  /api/chat/{session_id}/messages — fetch full message history for a session
+    POST /api/chat/eligibility          — raw SQL eligibility check (no LLM)
+    POST /api/chat/eligibility/{major_id} — scoped raw eligibility check
+    GET  /api/chat/sessions             — list user's chat sessions
 """
 
 from __future__ import annotations
@@ -15,17 +14,50 @@ from __future__ import annotations
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from auth.firebase_admin import get_current_user
 from db.postgres import execute, fetch, fetchrow
 from engines.eligibility_engine import check_eligibility, check_eligibility_for_major
+from engines.mode_selector import validate_mode
+from engines.orchestrator import handle_message
+from memory.long_term_memory import (
+    create_chat_session,
+    get_messages,
+    get_session,
+    save_message,
+)
 
 router = APIRouter()
 
 
-# ── Response models ───────────────────────────────────────────────────────────
+# ── Request / response models ─────────────────────────────────────────────────
+
+class CreateSessionRequest(BaseModel):
+    ai_mode: str
+
+
+class CreateSessionResponse(BaseModel):
+    session_id: str
+    ai_mode: str
+
+
+class SendMessageRequest(BaseModel):
+    content: str
+
+
+class MessageResponse(BaseModel):
+    role: str
+    content: str
+
+
+class HistoryResponse(BaseModel):
+    session_id: str
+    messages: list[dict]
+
+
+# ── Eligibility response models ───────────────────────────────────────────────
 
 class SubjectResult(BaseModel):
     subject: str


### PR DESCRIPTION
## What this does
Implements the full Phase 8 online runtime layer on top of the existing eligibility engine.

**19 commits, one function per commit:**
- `memory/session_memory.py` — 3 new functions: `get_chat_window`, `set_chat_window`, `append_to_chat_window` (Redis, TTL 2h, capped at 10 messages)
- `memory/long_term_memory.py` — 4 functions: `create_chat_session`, `save_message`, `get_session`, `get_messages` (Postgres durable history)
- `engines/mode_selector.py` — `validate_mode()` — explicit UI routing, no LLM intent classification (CLAUDE.md §6.1)
- `engines/prompt_composer.py` — `_MASTER_SYSTEM` + `compose_dreamer_prompt` + `compose_tcas_prompt` (eligibility results capped 10/5, wrapped in `<sql_result>` tags)
- `engines/orchestrator.py` — `_load_user_profile` (Redis→DB fallback) + `handle_dreamer_message` + `handle_tcas_message` + `handle_message` dispatcher
- `routers/chat.py` — 3 new endpoints: `POST /session`, `POST /{session_id}/message`, `GET /{session_id}/messages`

RAG slot is intentionally left empty in `handle_tcas_message` — Phase 6 will fill it.

## Issues
Closes #36
Closes #38
Closes #39
Closes #40

## How to test
1. `docker compose up` (postgres, redis, ollama running)
2. Register + login → get Firebase idToken
3. `PUT /api/profile/me` with GPAX + test scores
4. `POST /api/chat/session` `{"ai_mode": "tcas_rag"}` → session_id
5. `POST /api/chat/{session_id}/message` `{"content": "ฉันสมัครมหาวิทยาลัยอะไรได้บ้าง"}` → AI response
6. `GET /api/chat/{session_id}/messages` → both messages persisted
7. Repeat with `{"ai_mode": "dreamer"}` — no eligibility check fires

## Notes
- Invalid `ai_mode` returns 422 (validated by `validate_mode` before DB write)
- Ownership check on all session-scoped endpoints — 404 if session belongs to another user