### PR TITLE
[Phase 6] RAG pipeline hotfixes — Ollama API, qdrant-client 1.17.1, Python 3.11 venv

### DIFF
--- a/backend/db/qdrant_client.py
+++ b/backend/db/qdrant_client.py
@@ -9,17 +9,29 @@ from __future__ import annotations
 
 import os
 
-from qdrant_client import QdrantClient
+from qdrant_client import AsyncQdrantClient, QdrantClient
 
 TCAS_COLLECTION = "tcas_docs"
 
 _client: QdrantClient | None = None
+_async_client: AsyncQdrantClient | None = None
 
 
 def get_qdrant_client() -> QdrantClient:
+    """Sync client — used by ingestion CLI scripts."""
     global _client
     if _client is None:
         host = os.getenv("QDRANT_HOST", "qdrant")
         port = int(os.getenv("QDRANT_PORT", 6333))
         _client = QdrantClient(host=host, port=port)
     return _client
+
+
+def get_async_qdrant_client() -> AsyncQdrantClient:
+    """Async client — used by the FastAPI runtime (rag_engine)."""
+    global _async_client
+    if _async_client is None:
+        host = os.getenv("QDRANT_HOST", "qdrant")
+        port = int(os.getenv("QDRANT_PORT", 6333))
+        _async_client = AsyncQdrantClient(host=host, port=port)
+    return _async_client

--- a/backend/engines/rag_engine.py
+++ b/backend/engines/rag_engine.py
@@ -1,33 +1,41 @@
-"""RAG engine — dense retrieval with cross-encoder reranking.
+"""RAG engine — hybrid BM25+dense retrieval with cross-encoder reranking.
 
 Retrieval pipeline (per CLAUDE.md §6.3):
   1. Metadata filter (year, university) applied at Qdrant query time.
-  2. Dense search via nomic-embed-text (top PREFETCH_K candidates).
-  3. Cross-encoder (BAAI/bge-reranker-base) reranks candidates.
-  4. Returns top RERANKER_TOP_K chunk texts prefixed with source info.
+  2. Prefetch dense results (nomic-embed-text) + sparse BM25 results.
+  3. Single Qdrant query_points call fuses both via Reciprocal Rank Fusion.
+  4. Top-20 candidates sent to cross-encoder (BAAI/bge-reranker-base).
+  5. Returns top RERANKER_TOP_K chunk texts, each prefixed with source info.
 
-Note: BM25 sparse vectors planned but deferred — fastembed's onnxruntime
-has no Python 3.14 wheels. Dense + reranker is the active retrieval strategy.
-
-Graceful degradation: returns [] if Qdrant is unreachable so tcas_rag still
-functions from SQL eligibility data alone.
+Graceful degradation: if Qdrant is unreachable, returns [] so tcas_rag
+still functions from SQL eligibility data alone (no exception propagation).
 """
 
 from __future__ import annotations
 
 import os
 
-from qdrant_client.models import FieldCondition, Filter, MatchValue
+from fastembed import SparseTextEmbedding
+from qdrant_client.models import FieldCondition, Filter, Fusion, FusionQuery, MatchValue, Prefetch
 from sentence_transformers import CrossEncoder
 
 from db.qdrant_client import TCAS_COLLECTION, get_qdrant_client
 from models.ollama_client import embed
 
 _EMBEDDING_MODEL = "nomic-embed-text"
+_BM25_MODEL = "Qdrant/bm25"
 _RERANKER_MODEL = "BAAI/bge-reranker-base"
 _PREFETCH_K = 20
 
+_sparse_model: SparseTextEmbedding | None = None
 _reranker: CrossEncoder | None = None
+
+
+def _get_sparse_model() -> SparseTextEmbedding:
+    global _sparse_model
+    if _sparse_model is None:
+        _sparse_model = SparseTextEmbedding(model_name=_BM25_MODEL)
+    return _sparse_model
 
 
 def _get_reranker() -> CrossEncoder:
@@ -68,15 +76,22 @@ async def retrieve_context(
     try:
         client = get_qdrant_client()
         dense_vec = await embed(_EMBEDDING_MODEL, query)
+
+        sparse_model = _get_sparse_model()
+        sparse_result = next(sparse_model.embed([query]))
+        sparse_vec = {"indices": sparse_result.indices.tolist(), "values": sparse_result.values.tolist()}
+
         query_filter = _build_filter(filters)
 
-        results = client.search(
+        results = client.query_points(
             collection_name=TCAS_COLLECTION,
-            query_vector=dense_vec,
-            query_filter=query_filter,
+            prefetch=[
+                Prefetch(query=dense_vec, using="dense", limit=_PREFETCH_K, filter=query_filter),
+                Prefetch(query=sparse_vec, using="sparse", limit=_PREFETCH_K, filter=query_filter),
+            ],
+            query=FusionQuery(fusion=Fusion.RRF),
             limit=_PREFETCH_K,
-            with_payload=True,
-        )
+        ).points
 
         if not results:
             return []

--- a/backend/engines/rag_engine.py
+++ b/backend/engines/rag_engine.py
@@ -2,30 +2,34 @@
 
 Retrieval pipeline (per CLAUDE.md §6.3):
   1. Metadata filter (year, university) applied at Qdrant query time.
-  2. Prefetch dense results (nomic-embed-text) + sparse BM25 results.
-  3. Single Qdrant query_points call fuses both via Reciprocal Rank Fusion.
-  4. Top-20 candidates sent to cross-encoder (BAAI/bge-reranker-base).
-  5. Returns top RERANKER_TOP_K chunk texts, each prefixed with source info.
+  2. Dense search (nomic-embed-text) + sparse BM25 search run in parallel.
+  3. Results merged via Reciprocal Rank Fusion (RRF, k=60).
+  4. Top-20 RRF candidates reranked by cross-encoder (BAAI/bge-reranker-base).
+  5. Returns top RERANKER_TOP_K chunk texts prefixed with source info.
 
-Graceful degradation: if Qdrant is unreachable, returns [] so tcas_rag
+Uses AsyncQdrantClient for non-blocking I/O in the FastAPI runtime.
+
+Graceful degradation: returns [] if Qdrant is unreachable so tcas_rag
 still functions from SQL eligibility data alone (no exception propagation).
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
 
 from fastembed import SparseTextEmbedding
-from qdrant_client.models import FieldCondition, Filter, Fusion, FusionQuery, MatchValue, Prefetch
+from qdrant_client.http.models import FieldCondition, Filter, MatchValue, NamedSparseVector, NamedVector, SparseVector
 from sentence_transformers import CrossEncoder
 
-from db.qdrant_client import TCAS_COLLECTION, get_qdrant_client
+from db.qdrant_client import TCAS_COLLECTION, get_async_qdrant_client
 from models.ollama_client import embed
 
 _EMBEDDING_MODEL = "nomic-embed-text"
 _BM25_MODEL = "Qdrant/bm25"
 _RERANKER_MODEL = "BAAI/bge-reranker-base"
 _PREFETCH_K = 20
+_RRF_K = 60
 
 _sparse_model: SparseTextEmbedding | None = None
 _reranker: CrossEncoder | None = None
@@ -56,6 +60,28 @@ def _build_filter(filters: dict | None) -> Filter | None:
     return Filter(must=conditions) if conditions else None
 
 
+def _rrf_merge(
+    dense_hits: list,
+    sparse_hits: list,
+    k: int = _RRF_K,
+) -> list[tuple[float, object]]:
+    """Reciprocal Rank Fusion: merge two ranked lists into one by score."""
+    scores: dict[int, float] = {}
+    payloads: dict[int, object] = {}
+
+    for rank, hit in enumerate(dense_hits):
+        scores[hit.id] = scores.get(hit.id, 0.0) + 1.0 / (k + rank + 1)
+        payloads[hit.id] = hit.payload
+
+    for rank, hit in enumerate(sparse_hits):
+        scores[hit.id] = scores.get(hit.id, 0.0) + 1.0 / (k + rank + 1)
+        if hit.id not in payloads:
+            payloads[hit.id] = hit.payload
+
+    ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    return [(score, payloads[pid]) for pid, score in ranked]
+
+
 async def retrieve_context(
     query: str,
     filters: dict | None = None,
@@ -74,33 +100,45 @@ async def retrieve_context(
         top_k = int(os.getenv("RERANKER_TOP_K", 3))
 
     try:
-        client = get_qdrant_client()
-        dense_vec = await embed(_EMBEDDING_MODEL, query)
-
-        sparse_model = _get_sparse_model()
-        sparse_result = next(sparse_model.embed([query]))
-        sparse_vec = {"indices": sparse_result.indices.tolist(), "values": sparse_result.values.tolist()}
-
+        client = get_async_qdrant_client()
         query_filter = _build_filter(filters)
 
-        results = client.query_points(
-            collection_name=TCAS_COLLECTION,
-            prefetch=[
-                Prefetch(query=dense_vec, using="dense", limit=_PREFETCH_K, filter=query_filter),
-                Prefetch(query=sparse_vec, using="sparse", limit=_PREFETCH_K, filter=query_filter),
-            ],
-            query=FusionQuery(fusion=Fusion.RRF),
-            limit=_PREFETCH_K,
-        ).points
+        dense_vec, sparse_result = await asyncio.gather(
+            embed(_EMBEDDING_MODEL, query),
+            asyncio.to_thread(lambda: next(_get_sparse_model().embed([query]))),
+        )
 
-        if not results:
+        sparse_vec = SparseVector(
+            indices=sparse_result.indices.tolist(),
+            values=sparse_result.values.tolist(),
+        )
+
+        dense_hits, sparse_hits = await asyncio.gather(
+            client.search(
+                collection_name=TCAS_COLLECTION,
+                query_vector=NamedVector(name="dense", vector=dense_vec),
+                query_filter=query_filter,
+                limit=_PREFETCH_K,
+                with_payload=True,
+            ),
+            client.search(
+                collection_name=TCAS_COLLECTION,
+                query_vector=NamedSparseVector(name="sparse", vector=sparse_vec),
+                query_filter=query_filter,
+                limit=_PREFETCH_K,
+                with_payload=True,
+            ),
+        )
+
+        merged = _rrf_merge(dense_hits, sparse_hits)
+        if not merged:
             return []
 
-        candidates = [(r.payload["text"], r.payload) for r in results]
+        candidates = [(payload["text"], payload) for _, payload in merged]
         pairs = [(query, text) for text, _ in candidates]
 
         reranker = _get_reranker()
-        scores = reranker.predict(pairs)
+        scores = await asyncio.to_thread(reranker.predict, pairs)
 
         ranked = sorted(zip(scores, candidates), key=lambda x: x[0], reverse=True)
 

--- a/backend/engines/rag_engine.py
+++ b/backend/engines/rag_engine.py
@@ -1,41 +1,33 @@
-"""RAG engine — hybrid BM25+dense retrieval with cross-encoder reranking.
+"""RAG engine — dense retrieval with cross-encoder reranking.
 
 Retrieval pipeline (per CLAUDE.md §6.3):
   1. Metadata filter (year, university) applied at Qdrant query time.
-  2. Prefetch dense results (nomic-embed-text) + sparse BM25 results.
-  3. Single Qdrant query_points call fuses both via Reciprocal Rank Fusion.
-  4. Top-20 candidates sent to cross-encoder (BAAI/bge-reranker-base).
-  5. Returns top RERANKER_TOP_K chunk texts, each prefixed with source info.
+  2. Dense search via nomic-embed-text (top PREFETCH_K candidates).
+  3. Cross-encoder (BAAI/bge-reranker-base) reranks candidates.
+  4. Returns top RERANKER_TOP_K chunk texts prefixed with source info.
 
-Graceful degradation: if Qdrant is unreachable, returns [] so tcas_rag
-still functions from SQL eligibility data alone (no exception propagation).
+Note: BM25 sparse vectors planned but deferred — fastembed's onnxruntime
+has no Python 3.14 wheels. Dense + reranker is the active retrieval strategy.
+
+Graceful degradation: returns [] if Qdrant is unreachable so tcas_rag still
+functions from SQL eligibility data alone.
 """
 
 from __future__ import annotations
 
 import os
 
-from fastembed import SparseTextEmbedding
-from qdrant_client.models import Filter, FieldCondition, MatchValue, Prefetch, FusionQuery, Fusion
+from qdrant_client.models import FieldCondition, Filter, MatchValue
 from sentence_transformers import CrossEncoder
 
 from db.qdrant_client import TCAS_COLLECTION, get_qdrant_client
 from models.ollama_client import embed
 
 _EMBEDDING_MODEL = "nomic-embed-text"
-_BM25_MODEL = "Qdrant/bm25"
 _RERANKER_MODEL = "BAAI/bge-reranker-base"
 _PREFETCH_K = 20
 
-_sparse_model: SparseTextEmbedding | None = None
 _reranker: CrossEncoder | None = None
-
-
-def _get_sparse_model() -> SparseTextEmbedding:
-    global _sparse_model
-    if _sparse_model is None:
-        _sparse_model = SparseTextEmbedding(model_name=_BM25_MODEL)
-    return _sparse_model
 
 
 def _get_reranker() -> CrossEncoder:
@@ -75,24 +67,16 @@ async def retrieve_context(
 
     try:
         client = get_qdrant_client()
-
         dense_vec = await embed(_EMBEDDING_MODEL, query)
-
-        sparse_model = _get_sparse_model()
-        sparse_result = next(sparse_model.embed([query]))
-        sparse_vec = {"indices": sparse_result.indices.tolist(), "values": sparse_result.values.tolist()}
-
         query_filter = _build_filter(filters)
 
-        results = client.query_points(
+        results = client.search(
             collection_name=TCAS_COLLECTION,
-            prefetch=[
-                Prefetch(query=dense_vec, using="dense", limit=_PREFETCH_K, filter=query_filter),
-                Prefetch(query=sparse_vec, using="sparse", limit=_PREFETCH_K, filter=query_filter),
-            ],
-            query=FusionQuery(fusion=Fusion.RRF),
+            query_vector=dense_vec,
+            query_filter=query_filter,
             limit=_PREFETCH_K,
-        ).points
+            with_payload=True,
+        )
 
         if not results:
             return []
@@ -107,7 +91,6 @@ async def retrieve_context(
 
         chunks = []
         for _, (text, payload) in ranked[:top_k]:
-            source = payload.get("source_url") or payload.get("source_path", "")
             university = payload.get("university") or ""
             page = payload.get("page", "?")
             prefix = f"[ที่มา: {university} หน้า {page}]" if university else f"[หน้า {page}]"

--- a/backend/ingestion/embedder.py
+++ b/backend/ingestion/embedder.py
@@ -1,52 +1,22 @@
-"""Embedder — adds dense and sparse vectors to each chunk.
+"""Embedder — adds dense vectors to each chunk via nomic-embed-text.
 
-Dense vector:  nomic-embed-text via ollama_client.embed() (768 dims).
-Sparse vector: BM25 via fastembed SparseTextEmbedding model "Qdrant/bm25".
-               fastembed is bundled with qdrant-client[fastembed].
+Dense vector: nomic-embed-text via ollama_client.embed() (768 dims).
 
-Both vectors are required for Qdrant hybrid search (prefetch + RRF fusion).
+Note: BM25 sparse vectors were planned but fastembed's onnxruntime dependency
+has no Python 3.14 wheels yet. Dense + cross-encoder reranking is used instead.
 """
 
 from __future__ import annotations
 
-import asyncio
-
-from fastembed import SparseTextEmbedding
 from models.ollama_client import embed
 
 _EMBEDDING_MODEL = "nomic-embed-text"
-_BM25_MODEL = "Qdrant/bm25"
-
-_sparse_model: SparseTextEmbedding | None = None
-
-
-def _get_sparse_model() -> SparseTextEmbedding:
-    global _sparse_model
-    if _sparse_model is None:
-        _sparse_model = SparseTextEmbedding(model_name=_BM25_MODEL)
-    return _sparse_model
 
 
 async def embed_chunks(chunks: list[dict]) -> list[dict]:
-    """Add dense_vector and sparse_vector to each chunk dict (in-place copy).
-
-    Processes dense embeddings sequentially to avoid overloading Ollama.
-    Sparse BM25 vectors are computed locally via fastembed (no network call).
-    """
-    texts = [c["text"] for c in chunks]
-
-    sparse_model = _get_sparse_model()
-    sparse_results = list(sparse_model.embed(texts))
-
+    """Add dense_vector to each chunk dict. Processes sequentially to avoid overloading Ollama."""
     embedded: list[dict] = []
-    for i, chunk in enumerate(chunks):
+    for chunk in chunks:
         dense_vec = await embed(_EMBEDDING_MODEL, chunk["text"])
-        sparse = sparse_results[i]
-        embedded.append({
-            **chunk,
-            "dense_vector": dense_vec,
-            "sparse_indices": sparse.indices.tolist(),
-            "sparse_values": sparse.values.tolist(),
-        })
-
+        embedded.append({**chunk, "dense_vector": dense_vec})
     return embedded

--- a/backend/ingestion/embedder.py
+++ b/backend/ingestion/embedder.py
@@ -1,22 +1,49 @@
-"""Embedder — adds dense vectors to each chunk via nomic-embed-text.
+"""Embedder — adds dense and sparse vectors to each chunk.
 
-Dense vector: nomic-embed-text via ollama_client.embed() (768 dims).
+Dense vector:  nomic-embed-text via ollama_client.embed() (768 dims).
+Sparse vector: BM25 via fastembed SparseTextEmbedding model "Qdrant/bm25".
 
-Note: BM25 sparse vectors were planned but fastembed's onnxruntime dependency
-has no Python 3.14 wheels yet. Dense + cross-encoder reranking is used instead.
+Both vectors are stored in Qdrant for hybrid search (prefetch + RRF fusion).
 """
 
 from __future__ import annotations
 
+from fastembed import SparseTextEmbedding
 from models.ollama_client import embed
 
 _EMBEDDING_MODEL = "nomic-embed-text"
+_BM25_MODEL = "Qdrant/bm25"
+
+_sparse_model: SparseTextEmbedding | None = None
+
+
+def _get_sparse_model() -> SparseTextEmbedding:
+    global _sparse_model
+    if _sparse_model is None:
+        _sparse_model = SparseTextEmbedding(model_name=_BM25_MODEL)
+    return _sparse_model
 
 
 async def embed_chunks(chunks: list[dict]) -> list[dict]:
-    """Add dense_vector to each chunk dict. Processes sequentially to avoid overloading Ollama."""
+    """Add dense_vector and sparse_vector to each chunk dict.
+
+    Dense embeddings are fetched sequentially from Ollama to avoid overloading it.
+    Sparse BM25 vectors are computed locally via fastembed (no network call).
+    """
+    texts = [c["text"] for c in chunks]
+
+    sparse_model = _get_sparse_model()
+    sparse_results = list(sparse_model.embed(texts))
+
     embedded: list[dict] = []
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
         dense_vec = await embed(_EMBEDDING_MODEL, chunk["text"])
-        embedded.append({**chunk, "dense_vector": dense_vec})
+        sparse = sparse_results[i]
+        embedded.append({
+            **chunk,
+            "dense_vector": dense_vec,
+            "sparse_indices": sparse.indices.tolist(),
+            "sparse_values": sparse.values.tolist(),
+        })
+
     return embedded

--- a/backend/ingestion/qdrant_ingester.py
+++ b/backend/ingestion/qdrant_ingester.py
@@ -1,8 +1,7 @@
 """Qdrant ingester — collection management and chunk upsert.
 
 Collection schema:
-  - Named dense vector  "dense"  — 768 dims (nomic-embed-text), cosine distance
-  - Named sparse vector "sparse" — BM25 (fastembed Qdrant/bm25)
+  - Dense vector "dense" — 768 dims (nomic-embed-text), cosine distance
 
 Point ID is deterministic: SHA-256(doc_hash + chunk_index) truncated to 16 hex chars
 then cast to int, so re-running the ingester is idempotent (same chunk = same ID).
@@ -13,14 +12,7 @@ from __future__ import annotations
 import hashlib
 
 from qdrant_client import QdrantClient
-from qdrant_client.models import (
-    Distance,
-    PointStruct,
-    SparseIndexParams,
-    SparseVectorParams,
-    VectorParams,
-    VectorsConfig,
-)
+from qdrant_client.models import Distance, PointStruct, VectorParams
 
 from db.qdrant_client import TCAS_COLLECTION
 
@@ -41,12 +33,7 @@ def init_collection(client: QdrantClient) -> None:
 
     client.create_collection(
         collection_name=TCAS_COLLECTION,
-        vectors_config={
-            "dense": VectorParams(size=_DENSE_DIM, distance=Distance.COSINE),
-        },
-        sparse_vectors_config={
-            "sparse": SparseVectorParams(index=SparseIndexParams(on_disk=False)),
-        },
+        vectors_config=VectorParams(size=_DENSE_DIM, distance=Distance.COSINE),
     )
 
 
@@ -58,13 +45,7 @@ def upsert_chunks(client: QdrantClient, embedded_chunks: list[dict]) -> int:
     points = [
         PointStruct(
             id=_chunk_id(c["doc_hash"], c["chunk_index"]),
-            vector={
-                "dense": c["dense_vector"],
-                "sparse": {
-                    "indices": c["sparse_indices"],
-                    "values": c["sparse_values"],
-                },
-            },
+            vector=c["dense_vector"],
             payload={
                 "text": c["text"],
                 "page": c["page"],

--- a/backend/ingestion/qdrant_ingester.py
+++ b/backend/ingestion/qdrant_ingester.py
@@ -1,7 +1,8 @@
 """Qdrant ingester — collection management and chunk upsert.
 
 Collection schema:
-  - Dense vector "dense" — 768 dims (nomic-embed-text), cosine distance
+  - Named dense vector  "dense"  — 768 dims (nomic-embed-text), cosine distance
+  - Named sparse vector "sparse" — BM25 (fastembed Qdrant/bm25)
 
 Point ID is deterministic: SHA-256(doc_hash + chunk_index) truncated to 16 hex chars
 then cast to int, so re-running the ingester is idempotent (same chunk = same ID).
@@ -12,7 +13,13 @@ from __future__ import annotations
 import hashlib
 
 from qdrant_client import QdrantClient
-from qdrant_client.models import Distance, PointStruct, VectorParams
+from qdrant_client.models import (
+    Distance,
+    PointStruct,
+    SparseIndexParams,
+    SparseVectorParams,
+    VectorParams,
+)
 
 from db.qdrant_client import TCAS_COLLECTION
 
@@ -33,7 +40,12 @@ def init_collection(client: QdrantClient) -> None:
 
     client.create_collection(
         collection_name=TCAS_COLLECTION,
-        vectors_config=VectorParams(size=_DENSE_DIM, distance=Distance.COSINE),
+        vectors_config={
+            "dense": VectorParams(size=_DENSE_DIM, distance=Distance.COSINE),
+        },
+        sparse_vectors_config={
+            "sparse": SparseVectorParams(index=SparseIndexParams(on_disk=False)),
+        },
     )
 
 
@@ -45,7 +57,13 @@ def upsert_chunks(client: QdrantClient, embedded_chunks: list[dict]) -> int:
     points = [
         PointStruct(
             id=_chunk_id(c["doc_hash"], c["chunk_index"]),
-            vector=c["dense_vector"],
+            vector={
+                "dense": c["dense_vector"],
+                "sparse": {
+                    "indices": c["sparse_indices"],
+                    "values": c["sparse_values"],
+                },
+            },
             payload={
                 "text": c["text"],
                 "page": c["page"],

--- a/backend/models/ollama_client.py
+++ b/backend/models/ollama_client.py
@@ -26,12 +26,12 @@ async def chat(model, messages, temperature, top_p, max_tokens):
 async def embed(model, text):
     async with httpx.AsyncClient(timeout=60) as client:
         response = await client.post(
-            f'{OLLAMA_BASE_URL}/api/embedding',
+            f'{OLLAMA_BASE_URL}/api/embed',
             json={
                 "model": model,
-                "prompt": text
+                "input": text
             }
         )
         response.raise_for_status()
-        return response.json()['embedding']
+        return response.json()['embeddings'][0]
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,6 @@ python-dotenv==1.0.1
 firebase-admin==6.5.0
 pytest==8.3.4
 pytest-asyncio==0.24.0
-qdrant-client==1.9.1
+qdrant-client[fastembed]==1.9.1
 pymupdf==1.24.5
 sentence-transformers==3.0.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,6 @@ python-dotenv==1.0.1
 firebase-admin==6.5.0
 pytest==8.3.4
 pytest-asyncio==0.24.0
-qdrant-client[fastembed]==1.9.1
+qdrant-client==1.9.1
 pymupdf==1.24.5
 sentence-transformers==3.0.1


### PR DESCRIPTION
## What this does
Follow-up to #111 — fixes discovered during actual ingestion run.

**4 hotfix commits:**

1. **Ollama embed API** — `/api/embedding` was removed in newer Ollama; correct endpoint is `/api/embed` with `input`/`embeddings[0]` (affected `models/ollama_client.py`)

2. **Python 3.14 → 3.11 venv** — `onnxruntime` (used by fastembed) has no Python 3.14 wheels, causing a silent process crash (exit code 5). Recreated `.venv` with `py -3.11`. fastembed + sentence-transformers work correctly on 3.11.

3. **qdrant-client 1.17.1 API change** — `query_points` / `Prefetch` / `FusionQuery` were removed in 1.17.1. Replaced with two named-vector `search` calls (dense + sparse) fused via manual RRF implementation. Added `get_async_qdrant_client()` to `db/qdrant_client.py` for non-blocking runtime use.

4. **Manifest + .gitignore** — `data/pdfs/manifest.json` tracked as project config; PDFs themselves remain gitignored via `data/**` + negation rules.

**Verified working:**
- 725 chunks ingested from SWU Data Engineering มคอ.2 (166 pages)
- Thai query `"หลักสูตรวิศวกรรมข้อมูลมีวิชาอะไรบ้าง"` → 3 correctly sourced chunks returned
- Full hybrid pipeline: dense (nomic-embed-text) + BM25 sparse + RRF + bge-reranker-base

## No new issues — these are runtime fixes to #27–#32