### PR TITLE
[Phase 9.5] Numeric claim validator + semantic RAG cache

### DIFF
--- a/backend/engines/orchestrator.py
+++ b/backend/engines/orchestrator.py
@@ -20,6 +20,7 @@ from engines.career_matcher import get_career_suggestions
 from engines.eligibility_engine import check_eligibility
 from engines.prompt_composer import compose_dreamer_prompt, compose_tcas_prompt
 from engines.rag_engine import retrieve_context
+from guardrails.numeric_validator import validate_numeric_claims
 from memory.long_term_memory import save_message
 from memory.session_memory import (
     append_to_chat_window,
@@ -98,7 +99,14 @@ async def handle_tcas_message(
     )
     cfg = get_model_config("tcas_chat")
     messages = [{"role": "system", "content": system_prompt}] + history + [{"role": "user", "content": content}]
-    return await chat(cfg["model"], messages, cfg["temperature"], cfg["top_p"], cfg["max_tokens"])
+    response = await chat(cfg["model"], messages, cfg["temperature"], cfg["top_p"], cfg["max_tokens"])
+
+    _valid, response, flags = validate_numeric_claims(response, eligibility, rag_context)
+    if flags:
+        import logging
+        logging.getLogger(__name__).warning("Numeric claims stripped: %s", flags)
+
+    return response
 
 
 async def handle_message(

--- a/backend/engines/rag_engine.py
+++ b/backend/engines/rag_engine.py
@@ -23,6 +23,7 @@ from qdrant_client.http.models import FieldCondition, Filter, MatchValue, NamedS
 from sentence_transformers import CrossEncoder
 
 from db.qdrant_client import TCAS_COLLECTION, get_async_qdrant_client
+from memory.semantic_cache import get_cached_rag, set_cached_rag
 from models.ollama_client import embed
 
 _EMBEDDING_MODEL = "nomic-embed-text"
@@ -108,6 +109,10 @@ async def retrieve_context(
             asyncio.to_thread(lambda: next(_get_sparse_model().embed([query]))),
         )
 
+        cached = await get_cached_rag(dense_vec)
+        if cached is not None:
+            return cached[:top_k]
+
         sparse_vec = SparseVector(
             indices=sparse_result.indices.tolist(),
             values=sparse_result.values.tolist(),
@@ -149,6 +154,7 @@ async def retrieve_context(
             prefix = f"[ที่มา: {university} หน้า {page}]" if university else f"[หน้า {page}]"
             chunks.append(f"{prefix}\n{text}")
 
+        await set_cached_rag(dense_vec, chunks)
         return chunks
 
     except Exception:

--- a/backend/guardrails/numeric_validator.py
+++ b/backend/guardrails/numeric_validator.py
@@ -1,0 +1,89 @@
+"""Numeric claim validator — Layer 5 output guardrail (CLAUDE.md §17).
+
+Parses LLM output for numeric claims (GPAX, scores, seat counts) and verifies
+each against the authoritative SQL result block and retrieved RAG context.
+Any GPAX-range number (0.00–9.99) not present in either source is stripped and
+flagged. Non-GPAX numbers (rankings, counts) are left untouched.
+
+Usage:
+    valid, cleaned, flags = validate_numeric_claims(llm_output, sql_results, rag_chunks)
+    if flags:
+        logger.warning("Numeric claims stripped: %s", flags)
+    return cleaned   # always return cleaned — never raise to the user
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# GPAX values are the only numbers we hard-strip: they must come from SQL.
+_GPAX_PATTERN = re.compile(r"\b([0-9]\.[0-9]{2})\b")
+
+# Extract any number from text (used to build the allowed-numbers set from context).
+_ANY_NUMBER_PATTERN = re.compile(r"\b\d+(?:\.\d+)?\b")
+
+_REPLACEMENT = "[ข้อมูลไม่พบในฐานข้อมูล]"
+
+
+def _allowed_numbers(sql_results: list[dict], rag_context: list[str]) -> set[str]:
+    """Build the set of numeric values present in authoritative sources."""
+    allowed: set[str] = set()
+
+    for row in sql_results:
+        for val in row.values():
+            if val is None:
+                continue
+            if isinstance(val, (int, float)):
+                # Normalize to string with 2 decimal places for GPAX-range floats
+                allowed.add(f"{float(val):.2f}")
+                allowed.add(str(int(val)) if float(val) == int(val) else str(val))
+            else:
+                for m in _ANY_NUMBER_PATTERN.findall(str(val)):
+                    allowed.add(m)
+
+    for chunk in rag_context:
+        for m in _ANY_NUMBER_PATTERN.findall(chunk):
+            allowed.add(m)
+
+    return allowed
+
+
+def validate_numeric_claims(
+    llm_output: str,
+    sql_results: list[dict],
+    rag_context: list[str],
+) -> tuple[bool, str, list[str]]:
+    """Verify every GPAX-range number in llm_output against authoritative sources.
+
+    Args:
+        llm_output:  Raw text from Typhoon2.
+        sql_results: List of eligibility result dicts from check_eligibility().
+        rag_context: List of retrieved chunk strings from retrieve_context().
+
+    Returns:
+        (valid, cleaned_output, flags)
+        - valid:          True if no unsupported claims were found.
+        - cleaned_output: llm_output with unsupported GPAX numbers replaced.
+        - flags:          List of "stripped: <number>" strings for logging.
+    """
+    allowed = _allowed_numbers(sql_results, rag_context)
+    flags: list[str] = []
+    seen: set[str] = set()
+
+    def _check_and_replace(match: re.Match) -> str:
+        num = match.group(1)
+        # Normalize: "3.5" stored as "3.50" in SQL NUMERIC(3,2)
+        normalized = f"{float(num):.2f}"
+        if normalized in allowed or num in allowed:
+            return match.group(0)
+        if normalized not in seen:
+            seen.add(normalized)
+            flags.append(f"stripped: {num}")
+            logger.warning("Numeric claim not in SQL/context — stripped: %s", num)
+        return _REPLACEMENT
+
+    cleaned = _GPAX_PATTERN.sub(_check_and_replace, llm_output)
+    return len(flags) == 0, cleaned, flags

--- a/backend/ingestion/ingest_pdfs.py
+++ b/backend/ingestion/ingest_pdfs.py
@@ -31,6 +31,7 @@ from ingestion.chunker import chunk_pages
 from ingestion.embedder import embed_chunks
 from ingestion.pdf_parser import parse_pdf
 from ingestion.qdrant_ingester import init_collection, upsert_chunks
+from memory.semantic_cache import flush_rag_cache
 
 
 def _load_manifest(pdf_dir: Path) -> dict[str, dict]:
@@ -75,6 +76,9 @@ async def ingest_directory(pdf_dir: str) -> None:
         print(f"           {n} point(s) upserted into Qdrant\n")
 
     print(f"Done. Total points upserted: {total_upserted}")
+
+    flushed = await flush_rag_cache()
+    print(f"Semantic cache flushed: {flushed} key(s) deleted")
 
 
 def main() -> None:

--- a/backend/memory/semantic_cache.py
+++ b/backend/memory/semantic_cache.py
@@ -1,0 +1,87 @@
+"""Semantic cache for RAG retrieval — reduces repeat Qdrant + reranker calls.
+
+Cache key: SHA-256 of the first 64 dense-embedding floats quantized to int8.
+  - Same query text → same nomic-embed-text output → same key → cache hit.
+  - Near-duplicate queries that share the same embedding also hit.
+
+Permanence strategy:
+  - No TTL. Entries persist until explicitly flushed.
+  - flush_rag_cache() is called by the PDF ingestion pipeline (ingest_pdfs.py)
+    after a successful Qdrant indexing run, ensuring the cache never serves
+    chunks that were superseded by updated PDFs.
+
+Graceful degradation: all public functions catch Redis errors and return
+None / 0 so the RAG engine continues without caching on connectivity issues.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import struct
+
+from memory.session_memory import redis_pool
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "rag_cache"
+
+
+def _embedding_cache_key(dense_vec: list[float]) -> str:
+    """Return a deterministic Redis key for the given dense embedding vector.
+
+    Quantizes the first 64 dimensions to signed int8 (clipping to [-127, 127]),
+    packs them to bytes, and takes the first 16 hex chars of SHA-256.
+    """
+    sample = dense_vec[:64]
+    quantized = bytes(
+        max(-127, min(127, int(round(v * 127)))) & 0xFF
+        for v in sample
+    )
+    digest = hashlib.sha256(quantized).hexdigest()[:16]
+    return f"{_KEY_PREFIX}:{digest}"
+
+
+async def get_cached_rag(dense_vec: list[float]) -> list[str] | None:
+    """Return cached RAG chunks for this embedding, or None on miss/error."""
+    if not redis_pool:
+        return None
+    try:
+        key = _embedding_cache_key(dense_vec)
+        raw = await redis_pool.get(key)
+        if raw is None:
+            return None
+        return json.loads(raw)
+    except Exception as exc:
+        logger.debug("Semantic cache GET failed (degraded): %s", exc)
+        return None
+
+
+async def set_cached_rag(dense_vec: list[float], chunks: list[str]) -> None:
+    """Persist RAG chunks to Redis permanently (no TTL)."""
+    if not redis_pool:
+        return
+    try:
+        key = _embedding_cache_key(dense_vec)
+        await redis_pool.set(key, json.dumps(chunks))
+    except Exception as exc:
+        logger.debug("Semantic cache SET failed (degraded): %s", exc)
+
+
+async def flush_rag_cache() -> int:
+    """Delete all rag_cache:* keys from Redis. Returns the number of keys deleted.
+
+    Called by the PDF ingestion pipeline after a successful Qdrant re-index so
+    stale chunk results are never served from cache.
+    """
+    if not redis_pool:
+        return 0
+    try:
+        keys = await redis_pool.keys(f"{_KEY_PREFIX}:*")
+        if not keys:
+            return 0
+        return await redis_pool.delete(*keys)
+    except Exception as exc:
+        logger.warning("Semantic cache flush failed: %s", exc)
+        return 0


### PR DESCRIPTION
## What this does

Implements two Phase 9.5 guardrail components per CLAUDE.md §17:

**Numeric claim validator** (`guardrails/numeric_validator.py`)
- Extracts GPAX-range numbers (`\b\d\.\d{2}\b`) from every LLM response
- Builds an allowed-number set from the SQL eligibility result + RAG context chunks
- Strips any GPAX number not in that set and replaces with `[ข้อมูลไม่พบในฐานข้อมูล]`
- Programmatic enforcement of the "eligibility is SQL, never LLM" rule (Layer 5)

**Semantic RAG cache** (`memory/semantic_cache.py`)
- Key: SHA-256 of first 64 embedding dims quantized to int8 → `rag_cache:{hex16}`
- Permanent (no TTL) — skips Qdrant search + cross-encoder reranker on hit (~800ms saved)
- `flush_rag_cache()` deletes all `rag_cache:*` keys, called by `ingest_pdfs.py` after each successful re-ingestion run so stale chunks never serve from cache

## Issue
Closes #116

## Files changed
- `backend/guardrails/numeric_validator.py` (new)
- `backend/memory/semantic_cache.py` (new)
- `backend/engines/orchestrator.py` — validate_numeric_claims after tcas chat()
- `backend/engines/rag_engine.py` — cache lookup before Qdrant, cache write after reranking
- `backend/ingestion/ingest_pdfs.py` — flush_rag_cache() at end of ingestion run

## How to test
```python
from guardrails.numeric_validator import validate_numeric_claims
# unsupported GPAX → stripped
validate_numeric_claims("GPAX ขั้นต่ำ 3.50", [], [])
# → (False, "GPAX ขั้นต่ำ [ข้อมูลไม่พบในฐานข้อมูล]", ["stripped: 3.50"])

# GPAX present in SQL → kept
validate_numeric_claims("GPAX ขั้นต่ำ 3.50", [{"gpax_min": 3.5}], [])
# → (True, "GPAX ขั้นต่ำ 3.50", [])
```