### PR TITLE
[phase-4] Implement session end summarization and PostgreSQL write-back (#22)

### DIFF
--- a/backend/engines/orchestrator.py
+++ b/backend/engines/orchestrator.py
@@ -31,6 +31,8 @@ from memory.session_memory import (
 )
 from models.model_router import get_model_config
 from models.ollama_client import chat
+from engines.summarizer import summarize_session
+import asyncio
 
 
 _COMPARISON_KW = ("เปรียบ", "compare", " vs ", "ต่าง", "ดีกว่า", "เทียบ", "versus")
@@ -135,5 +137,10 @@ async def handle_message(
 
     await append_to_chat_window(str(user_id), str(session_id), "user", content)
     await append_to_chat_window(str(user_id), str(session_id), "assistant", response)
+
+    # Trigger periodic background summarization (every 5 turns)
+    signals = await get_signals(str(user_id), str(session_id))
+    if signals.get("total_count", 0) > 0 and signals["total_count"] % 5 == 0:
+        asyncio.create_task(summarize_session(user_id, session_id))
 
     return response

--- a/backend/engines/summarizer.py
+++ b/backend/engines/summarizer.py
@@ -1,0 +1,135 @@
+import json
+import logging
+from uuid import UUID
+
+from db.postgres import execute
+from memory.long_term_memory import get_messages
+from models.model_router import get_model_config
+from models.ollama_client import chat
+
+logger = logging.getLogger(__name__)
+
+async def summarize_session(user_id: UUID, session_id: UUID) -> None:
+    """Summarize a chat session and extract structural insights using Typhoon2.
+    
+    The extracted JSON is saved to user_career_profiles.
+    """
+    messages = await get_messages(session_id)
+    if not messages:
+        logger.info(f"No messages found for session {session_id}, skipping summarization.")
+        return
+
+    # Format conversation history
+    chat_history = ""
+    for msg in messages:
+        role = msg["role"]
+        content = msg["content"]
+        chat_history += f"{role}: {content}\n"
+
+    system_prompt = (
+        "You are an expert AI extraction system for Thai high school students (TCAS system).\n"
+        "Analyze the following conversation history between a student and an AI advisor.\n"
+        "Your task is to extract structured profile information and return EXACTLY a valid JSON object.\n\n"
+        "EXPECTED JSON SCHEMA:\n"
+        "{\n"
+        '  "personality_summary": "A 2-3 sentence summary of the user\'s personality, academic habits, and traits in Thai",\n'
+        '  "strengths": {\n'
+        '    "skills": ["Skill 1", "Skill 2"],\n'
+        '    "explored_majors": ["คณะวิศวกรรมศาสตร์", "คณะวิทยาศาสตร์"],\n'
+        '    "career_interests": ["Programmer", "Data Scientist"]\n'
+        "  },\n"
+        '  "user_profile_updates": {\n'
+        '    "current_school": "ชื่อโรงเรียน (ถ้ามี)",\n'
+        '    "gpax": 3.50\n'
+        "  }\n"
+        "}\n\n"
+        "INSTRUCTIONS:\n"
+        "1. Extract the majors and careers the user explicitly mentioned or showed interest in.\n"
+        "2. If the user mentions their GPAX or current school, extract it into `user_profile_updates`.\n"
+        "3. If there is not enough information for a field, provide an empty list `[]`, empty string `\"\"`, or `null`.\n"
+        "4. Output MUST be valid JSON only, without any markdown formatting like ```json ... ```."
+    )
+
+    try:
+        cfg = get_model_config("dreamer_chat")
+        
+        # We enforce a strict JSON output by prompting.
+        response_text = await chat(
+            model=cfg["model"],
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": f"Conversation History:\n{chat_history}"}
+            ],
+            temperature=0.1,  # Lower temperature for extraction
+            top_p=0.9,
+            max_tokens=500
+        )
+        
+        # Clean up response text to ensure it's JSON (sometimes models add markdown formatting)
+        response_text = response_text.strip()
+        if response_text.startswith("```json"):
+            response_text = response_text[7:]
+        if response_text.endswith("```"):
+            response_text = response_text[:-3]
+        response_text = response_text.strip()
+        
+        extracted_data = json.loads(response_text)
+        
+        personality_summary = extracted_data.get("personality_summary", "")
+        strengths = extracted_data.get("strengths", {})
+
+        # Ensure user_career_profiles row exists or update it
+        await execute(
+            """
+            INSERT INTO user_career_profiles (user_id, personality_summary, strengths, updated_at)
+            VALUES ($1, $2, $3::jsonb, CURRENT_TIMESTAMP)
+            ON CONFLICT (user_id) 
+            DO UPDATE SET 
+                personality_summary = EXCLUDED.personality_summary,
+                strengths = EXCLUDED.strengths,
+                updated_at = EXCLUDED.updated_at
+            """,
+            user_id,
+            personality_summary,
+            json.dumps(strengths)
+        )
+        
+        # Update user_profiles if new data is found
+        user_profile_updates = extracted_data.get("user_profile_updates", {})
+        if user_profile_updates:
+            current_school = user_profile_updates.get("current_school")
+            gpax = user_profile_updates.get("gpax")
+            
+            set_clauses = []
+            values = [user_id]
+            if current_school and str(current_school).strip():
+                values.append(str(current_school).strip())
+                set_clauses.append(f"current_school = ${len(values)}")
+            
+            if gpax is not None and str(gpax).strip():
+                try:
+                    gpax_float = float(gpax)
+                    values.append(gpax_float)
+                    set_clauses.append(f"gpax = ${len(values)}")
+                except ValueError:
+                    pass
+            
+            if set_clauses:
+                set_clauses.append("updated_at = CURRENT_TIMESTAMP")
+                query = f"""
+                    INSERT INTO user_profiles (user_id, current_school, gpax, updated_at)
+                    VALUES ($1, {f'${len(values)-1}' if current_school else 'NULL'}, {f'${len(values)}' if gpax else 'NULL'}, CURRENT_TIMESTAMP)
+                    ON CONFLICT (user_id) DO UPDATE SET {', '.join(set_clauses)}
+                """
+                # Handle the dynamic INSERT VALUES correctly or just do an UPDATE since we have ON CONFLICT
+                # Actually, simpler is to do an UPDATE since profile creation is usually handled elsewhere.
+                # If we want to be safe, we can just do UPDATE.
+                update_query = f"UPDATE user_profiles SET {', '.join(set_clauses)} WHERE user_id = $1"
+                await execute(update_query, *values)
+
+        logger.info(f"Successfully summarized and saved profile for user {user_id} from session {session_id}")
+
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse JSON from summarizer output for session {session_id}: {e}")
+    except Exception as e:
+        logger.error(f"Error during session summarization for session {session_id}: {e}")

--- a/backend/memory/session_memory.py
+++ b/backend/memory/session_memory.py
@@ -62,6 +62,14 @@ async def get_user_session(user_id: str) -> dict | None:
     return json.loads(raw) if raw else None
 
 
+async def clear_user_session(user_id: str):
+    """Clear the cached profile session."""
+    if not redis_pool:
+        raise ConnectionError("Redis pool is not initialized.")
+    session_key = f"session:{user_id}:profile"
+    await redis_pool.delete(session_key)
+
+
 _WINDOW_SIZE = 10  # max messages kept hot in Redis per session
 
 
@@ -91,6 +99,15 @@ async def append_to_chat_window(user_id: str, session_id: str, role: str, conten
     if len(messages) > _WINDOW_SIZE:
         messages = messages[-_WINDOW_SIZE:]
     await set_chat_window(user_id, session_id, messages, ttl=ttl)
+
+
+async def clear_chat_window(user_id: str, session_id: str):
+    """Clear the chat window and associated signals from Redis."""
+    if not redis_pool:
+        raise ConnectionError("Redis pool is not initialized.")
+    window_key = f"session:{user_id}:{session_id}:window"
+    signals_key = f"session:{user_id}:{session_id}:signals"
+    await redis_pool.delete(window_key, signals_key)
 
 
 _SIGNALS_TTL = 7200

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,12 +1,14 @@
 from uuid import UUID
 
 import asyncpg
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Depends
 from pydantic import BaseModel, Field
 
-from auth.firebase_admin import verify_token
+from auth.firebase_admin import verify_token, get_current_user
 from db.postgres import fetchrow, execute
-from memory.session_memory import set_user_session
+from memory.session_memory import set_user_session, clear_user_session, clear_chat_window
+from engines.summarizer import summarize_session
+import asyncio
 
 router = APIRouter()
 
@@ -144,3 +146,30 @@ async def login_user(req: LoginRequest):
         user_id=user_id,
         username=user_record["username"]
     )
+
+
+@router.post(
+    "/logout",
+    summary="Log out a user",
+    description="Clears the user profile from Redis and triggers summarization for the most recent chat session.",
+)
+async def logout_user(user: dict = Depends(get_current_user)):
+    user_id = user["id"]
+    
+    # Find most recent chat session to summarize and clear
+    recent_session = await fetchrow(
+        "SELECT id FROM chat_sessions WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1",
+        user_id
+    )
+    
+    if recent_session:
+        session_id = recent_session["id"]
+        # Trigger background summarization
+        asyncio.create_task(summarize_session(user_id, session_id))
+        # Clear chat window
+        await clear_chat_window(str(user_id), str(session_id))
+        
+    # Clear global user session
+    await clear_user_session(str(user_id))
+    
+    return {"status": "ok", "message": "Logged out successfully."}

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -29,6 +29,9 @@ from memory.long_term_memory import (
     get_session,
     save_message,
 )
+from memory.session_memory import clear_chat_window, clear_user_session
+from engines.summarizer import summarize_session
+import asyncio
 
 router = APIRouter()
 
@@ -152,6 +155,28 @@ async def get_message_history(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
     messages = await get_messages(session_id)
     return HistoryResponse(session_id=str(session_id), messages=messages)
+
+
+@router.post(
+    "/{session_id}/end",
+    summary="End a session, trigger summarization and clear cache",
+)
+async def end_session(
+    session_id: UUID,
+    user: dict = Depends(get_current_user),
+):
+    session = await get_session(session_id)
+    if not session or session["user_id"] != user["id"]:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+    
+    # Trigger summarization in the background so we don't block the client
+    asyncio.create_task(summarize_session(user["id"], session_id))
+    
+    # Clear the session cache
+    await clear_chat_window(str(user["id"]), str(session_id))
+    await clear_user_session(str(user["id"]))
+    
+    return {"status": "ok", "message": "Session ended and summarization started"}
 
 
 # ── Eligibility endpoints ──────────────────────────────────────────────────────

--- a/backend/tests/test_summarizer.py
+++ b/backend/tests/test_summarizer.py
@@ -1,0 +1,61 @@
+import json
+import pytest
+from unittest.mock import patch
+from db.postgres import fetchrow
+from engines.summarizer import summarize_session
+from memory.long_term_memory import create_chat_session, save_message
+
+@pytest.mark.asyncio
+async def test_summarize_session_writes_to_db(make_user, db_pool):
+    """Test that summarizing a session successfully extracts and stores the profile data."""
+    # 1. Setup User and Session
+    user_id = await make_user()
+    session_id = await create_chat_session(user_id, "dreamer")
+    
+    # 2. Add Mock Chat History
+    await save_message(session_id, "user", "ผมอยากเป็นโปรแกรมเมอร์ ต้องเรียนคณะอะไรครับ?")
+    await save_message(session_id, "assistant", "แนะนำให้เรียนคณะวิศวกรรมศาสตร์ สาขาคอมพิวเตอร์ครับ หรือวิทยาศาสตร์คอมพิวเตอร์")
+    
+    # 3. Mock the Ollama LLM response to simulate Typhoon2 returning JSON
+    mock_json_response = json.dumps({
+        "personality_summary": "ผู้ใช้มีความสนใจในด้านเทคโนโลยีและการเขียนโปรแกรม",
+        "strengths": {
+            "skills": ["Programming"],
+            "explored_majors": ["คณะวิศวกรรมศาสตร์", "วิทยาศาสตร์คอมพิวเตอร์"],
+            "career_interests": ["Programmer"]
+        },
+        "user_profile_updates": {
+            "current_school": "Triam Udom",
+            "gpax": 3.85
+        }
+    })
+    
+    # 4. Execute the Summarizer with mocked LLM
+    with patch("engines.summarizer.chat", return_value=mock_json_response) as mock_chat:
+        await summarize_session(user_id, session_id)
+        
+        # Verify that the LLM was called
+        mock_chat.assert_called_once()
+        
+    # 5. Verify the results in PostgreSQL
+    profile_row = await fetchrow(
+        "SELECT personality_summary, strengths FROM user_career_profiles WHERE user_id = $1",
+        user_id
+    )
+    
+    assert profile_row is not None
+    assert profile_row["personality_summary"] == "ผู้ใช้มีความสนใจในด้านเทคโนโลยีและการเขียนโปรแกรม"
+    
+    # Parse the JSONB strengths column
+    strengths = json.loads(profile_row["strengths"])
+    assert "Programmer" in strengths["career_interests"]
+    assert "คณะวิศวกรรมศาสตร์" in strengths["explored_majors"]
+
+    # Verify the user_profiles table update
+    user_profile_row = await fetchrow(
+        "SELECT current_school, gpax FROM user_profiles WHERE user_id = $1",
+        user_id
+    )
+    assert user_profile_row is not None
+    assert user_profile_row["current_school"] == "Triam Udom"
+    assert float(user_profile_row["gpax"]) == 3.85


### PR DESCRIPTION
Resolves #22

**What this PR does:**
This PR completes the Phase 4 requirements by automatically summarizing user chat sessions and persisting their traits to the database.

**Key Changes:**
* **Summarizer Engine (`engines/summarizer.py`)**: Prompts Typhoon2 to parse session messages into structured JSON (`personality_summary`, `strengths`, `user_profile_updates`), updating PostgreSQL directly.
* **N Turns Trigger (`engines/orchestrator.py`)**: Automatically fires a background summarization task every 5 turns to keep profile data fresh during long sessions.
* **Session Termination Endpoints**: 
  * Added `POST /api/chat/{session_id}/end` to explicitly finalize a session.
  * Added `POST /api/auth/logout` to clear the user's active session and trigger a final summary.
* **Redis Memory Management (`memory/session_memory.py`)**: Implemented `clear_chat_window` and `clear_user_session` to aggressively evict session data on completion.
* **Testing (`tests/test_summarizer.py`)**: Added an asynchronous unit test that mocks Typhoon2's JSON extraction and verifies the correct PostgreSQL `UPDATE/INSERT` behaviors.
